### PR TITLE
Added the Winston logging support

### DIFF
--- a/thali/package.json
+++ b/thali/package.json
@@ -4,7 +4,8 @@
   "description": "Thali Cordova Plugin",
   "main": "thalireplicationmanager.js",
   "dependencies": {
-    "multiplex": "^6.2.2"
+    "multiplex": "^6.2.2",
+    "winston":"^1.0.1"
   },
   "scripts": {
     "prepublish" : "jx install/prePublishThaliCordovaPlugin.js",

--- a/thali/thalilogger.js
+++ b/thali/thalilogger.js
@@ -2,8 +2,31 @@
 
 var winston = require('winston');
 
-module.exports = function(){
-    return winston;
+module.exports = function(tag){
+    if (!tag || typeof tag !== 'string' || tag.length < 3) {
+        throw new Error("All logging must have a tag that is at least 3 characters long!");
+    }
+
+    var logger = new (winston.Logger)({
+        transports: [
+            new (winston.transports.Console)({
+                timestamp: function() {
+                    return Date.now();
+                },
+                formatter: function(options) {
+                    return options.timestamp() +' '+ options.level.toUpperCase() +' '+ options.meta.tag  +
+                        ' =>' +  (undefined !== options.message ? options.message : '') ;
+                }
+            })
+        ]
+    });
+    logger.addRewriter(function(level, msg, meta) {
+        if (!meta.tag) {
+            meta.tag = tag;
+        }
+        return meta;
+    });
+    return logger;
 }
 
 

--- a/thali/thalilogger.js
+++ b/thali/thalilogger.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var winston = require('winston');
+
+module.exports = function(){
+    return winston;
+}
+
+

--- a/thali/thalilogger.js
+++ b/thali/thalilogger.js
@@ -6,16 +6,12 @@ module.exports = function(tag){
     if (!tag || typeof tag !== 'string' || tag.length < 3) {
         throw new Error("All logging must have a tag that is at least 3 characters long!");
     }
-
     var logger = new (winston.Logger)({
         transports: [
             new (winston.transports.Console)({
-                timestamp: function() {
-                    return Date.now();
-                },
                 formatter: function(options) {
-                    return options.timestamp() +' '+ options.level.toUpperCase() +' '+ options.meta.tag  +
-                        ' =>' +  (undefined !== options.message ? options.message : '') ;
+                    return options.level.toUpperCase() +' '+ options.meta.tag  +
+                        ' ' +  (undefined !== options.message ? options.message : '') ;
                 }
             })
         ]
@@ -28,5 +24,3 @@ module.exports = function(tag){
     });
     return logger;
 }
-
-


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36918322%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36918747%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36919733%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36924532%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36929789%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36929809%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36993576%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36993865%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36994024%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2022bae7661cb154845b72467b79d8aa542376b517%20thali/thalilogger.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36918747%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22O.k.%20this%20is%20a%20question%20of%20aesthetics%20but%20I%20honestly%20don%27t%20think%20this%20is%20pretty.%20It%20means%20people%20have%20to%3A%5Cr%5Cn%5Cr%5Cn%60%60%60javascript%5Cr%5Cnvar%20thaliLogger%20%3D%20require%28%27thalilogger%27%29%3B%5Cr%5Cnvar%20loggingObject%20%3D%20thaliLogger%28%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnOr%20the%20equally%20inelegant%3A%5Cr%5Cn%5Cr%5Cn%60%60%60javascript%5Cr%5Cnvar%20logger%20%3D%20require%28%27thalilogger%27%29%28%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnWhy%20not%20just%20change%20the%20code%20to%3A%5Cr%5Cn%60%60%60Javascript%5Cr%5Cnmodule.exports%20%3D%20return%20winston%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnThat%20way%20logging%20becomes%3A%5Cr%5Cn%5Cr%5Cn%60%60%60Javascript%5Cr%5Cnvar%20logger%20%3D%20require%28%27thalilogger%27%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnBut%20that%20is%20just%20a%20general%20point.%20%22%2C%20%22created_at%22%3A%20%222015-08-12T21%3A50%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20as%20part%20of%20below.%22%2C%20%22created_at%22%3A%20%222015-08-13T00%3A12%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5561852%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sreesharp%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-13T16%3A21%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalilogger.js%3AL1-10%22%7D%2C%20%22Pull%2022bae7661cb154845b72467b79d8aa542376b517%20thali/thalilogger.js%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36919733%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Per%20the%20IM%20conversation%20I%27m%20wondering%20if%20we%20should%20just%20throw%20in%20a%20rewriter%20that%20will%20add%20a%20tag%20element%20to%20the%20metadata%20with%20a%20tag%20value%20passed%20in%20on%20the%20require.%20In%20other%20words%3A%5Cr%5Cn%5Cr%5Cn%60%60%60Javascript%5Cr%5Cnmodule.exports%20%3D%20function%28tag%29%20%7B%5Cr%5Cn%20%20%20if%20%28%21tag%20%7C%7C%20typeof%20tag%20%21%3D%3D%20%27string%27%20%7C%7C%20tag.length%20%3C%203%29%20%7B%5Cr%5Cn%20%20%20%20%20%20throw%20new%20Exception%28%5C%22All%20logging%20must%20have%20a%20tag%20that%20is%20at%20least%203%20characters%20long%21%5C%22%29%3B%5Cr%5Cn%20%20%20%7D%5Cr%5Cn%20%20%20winston.addRewriter%28function%28level%2C%20msg%2C%20meta%29%20%7B%5Cr%5Cn%20%20%20%20%20%20if%20%28%21meta.tag%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20meta.tag%20%3D%20tag%3B%5Cr%5Cn%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%20%20return%20meta%3B%5Cr%5Cn%20%20%20%7D%29%3B%5Cr%5Cn%20%20%20return%20winston%3B%5Cr%5Cn%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnOr%20something%20like%20that.%5Cr%5Cn%20%22%2C%20%22created_at%22%3A%20%222015-08-12T22%3A00%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed.%20Here%20is%20the%20sample%20output%20from%20logcat%5Cr%5Cn1439424437323%20INFO%20app.js%20%3D%3Estarting%20app.js%22%2C%20%22created_at%22%3A%20%222015-08-13T00%3A12%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5561852%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sreesharp%22%7D%7D%2C%20%7B%22body%22%3A%20%22Outputting%20a%20big%20number%20like%20a%20timestamp%20isn%27t%20terribly%20useful%20to%20someone%20reading%20the%20console.%20Also%20logcat%20automatically%20time%20stamps%20all%20of%20its%20output%20anyway%20%28with%20a%20human%20readable%20string%29.%20So%20please%20remove%20the%20timestamp%28%29%20from%20line%2017%20and%20then%20you%20can%20check%20this%20in%21%22%2C%20%22created_at%22%3A%20%222015-08-13T16%3A23%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalilogger.js%3AL1-10%22%7D%2C%20%22Pull%2022bae7661cb154845b72467b79d8aa542376b517%20thali/thalilogger.js%203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/68%23discussion_r36918322%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20hard%20code%20for%20now%20a%20call%20in%20our%20default%20winston%20instance%20to%20always%20output%20everything%20to%20console%20and%20then%20file%20a%20bug%20to%20remove%20that%20at%20some%20point%20since%20it%20obviously%20shouldn%27t%20go%20into%20production.%22%2C%20%22created_at%22%3A%20%222015-08-12T21%3A46%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22if%20we%20don%27t%20specify%20any%20transports%2C%20the%20default%20output%20is%20console.%20%20%20Created%20the%20issue%20%2374.%22%2C%20%22created_at%22%3A%20%222015-08-12T22%3A54%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5561852%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sreesharp%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-13T16%3A18%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalilogger.js%3AL1-10%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 22bae7661cb154845b72467b79d8aa542376b517 thali/thalilogger.js 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/68#discussion_r36919733'>File: thali/thalilogger.js:L1-10</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Per the IM conversation I'm wondering if we should just throw in a rewriter that will add a tag element to the metadata with a tag value passed in on the require. In other words:
```Javascript
module.exports = function(tag) {
if (!tag || typeof tag !== 'string' || tag.length < 3) {
throw new Exception("All logging must have a tag that is at least 3 characters long!");
}
winston.addRewriter(function(level, msg, meta) {
if (!meta.tag) {
meta.tag = tag;
}
return meta;
});
return winston;
}
```
Or something like that.
- <a href='https://github.com/sreesharp'><img border=0 src='https://avatars.githubusercontent.com/u/5561852?v=3' height=16 width=16'></a> Fixed. Here is the sample output from logcat
1439424437323 INFO app.js =>starting app.js
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Outputting a big number like a timestamp isn't terribly useful to someone reading the console. Also logcat automatically time stamps all of its output anyway (with a human readable string). So please remove the timestamp() from line 17 and then you can check this in!
- [x] <a href='#crh-comment-Pull 22bae7661cb154845b72467b79d8aa542376b517 thali/thalilogger.js 3'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/68#discussion_r36918322'>File: thali/thalilogger.js:L1-10</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> We should hard code for now a call in our default winston instance to always output everything to console and then file a bug to remove that at some point since it obviously shouldn't go into production.
- <a href='https://github.com/sreesharp'><img border=0 src='https://avatars.githubusercontent.com/u/5561852?v=3' height=16 width=16'></a> if we don't specify any transports, the default output is console.   Created the issue #74.
- [x] <a href='#crh-comment-Pull 22bae7661cb154845b72467b79d8aa542376b517 thali/thalilogger.js 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/68#discussion_r36918747'>File: thali/thalilogger.js:L1-10</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> O.k. this is a question of aesthetics but I honestly don't think this is pretty. It means people have to:
```javascript
var thaliLogger = require('thalilogger');
var loggingObject = thaliLogger();
```
Or the equally inelegant:
```javascript
var logger = require('thalilogger')();
```
Why not just change the code to:
```Javascript
module.exports = return winston;
```
That way logging becomes:
```Javascript
var logger = require('thalilogger');
```
But that is just a general point.
- <a href='https://github.com/sreesharp'><img border=0 src='https://avatars.githubusercontent.com/u/5561852?v=3' height=16 width=16'></a> Fixed as part of below.


<a href='https://www.codereviewhub.com/thaliproject/Thali_CordovaPlugin/pull/68?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/thaliproject/Thali_CordovaPlugin/pull/68?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/68'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>