### PR TITLE
Patching replication manager

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,6 +25,7 @@
         <framework src="src/android/JXcore.gradle" custom="true" type="gradleReference" />
         <source-file src="src/android/java/io/jxcore/node/BtToRequestSocket.java" target-dir="src/io/jxcore/node/" />
         <source-file src="src/android/java/io/jxcore/node/BtToServerSocket.java" target-dir="src/io/jxcore/node/" />
+        <source-file src="src/android/java/io/jxcore/node/BtToSocketBase.java" target-dir="src/io/jxcore/node/" />
         <source-file src="src/android/java/io/jxcore/node/StreamCopyingThread.java" target-dir="src/io/jxcore/node/" />
         <source-file src="src/android/java/io/jxcore/node/BtConnectorHelper.java" target-dir="src/io/jxcore/node/" />
         <source-file src="src/android/java/io/jxcore/node/ConnectivityMonitor.java" target-dir="src/io/jxcore/node/" />

--- a/src/android/java/io/jxcore/node/BtConnectorHelper.java
+++ b/src/android/java/io/jxcore/node/BtConnectorHelper.java
@@ -14,6 +14,7 @@ import org.thaliproject.p2p.btconnectorlib.BTConnector;
 import org.thaliproject.p2p.btconnectorlib.BTConnectorSettings;
 import org.thaliproject.p2p.btconnectorlib.ServiceItem;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -113,11 +114,12 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
     public boolean  DisconnectIncomingConnections() {
 
         boolean ret = false;
-        for(BtToServerSocket rSocket : mServerSocketList){
+        Iterator<BtToServerSocket> iterator = mServerSocketList.iterator();
+        while (iterator.hasNext()) {
+            BtToServerSocket rSocket = iterator.next();
             if (rSocket != null) {
                 print_debug("Disconnect:::Stop : mBtToServerSocket :" + rSocket.getName());
                 rSocket.Stop();
-                mServerSocketList.remove(rSocket);
                 ret = true;
             }
         }
@@ -152,7 +154,10 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
         }
 
         ServiceItem selectedDevice = null;
-        for (ServiceItem item: lastAvailableList) {
+
+        Iterator<ServiceItem> iterator = lastAvailableList.iterator();
+        while (iterator.hasNext()) {
+            ServiceItem item = iterator.next();
             if (item != null && item.peerId.contentEquals(toPeerId)) {
                 selectedDevice = item;
                 break;
@@ -266,7 +271,9 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
 
         print_debug("BT Disconnected with error : " + Error);
 
-        for (BtToServerSocket rSocket : mServerSocketList) {
+        Iterator<BtToServerSocket> iterator = mServerSocketList.iterator();
+        while (iterator.hasNext()) {
+            BtToServerSocket rSocket = iterator.next();
             if (rSocket != null && (rSocket.getId() == who.getId())) {
                 print_debug("Disconnect:::Stop : mBtToServerSocket :" + rSocket.GetPeerName());
                 rSocket.Stop();
@@ -282,7 +289,9 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
 
         boolean isDiscovered = false;
 
-        for (ServiceItem item: lastAvailableList) {
+        Iterator<ServiceItem> iterator = lastAvailableList.iterator();
+        while (iterator.hasNext()) {
+            ServiceItem item = iterator.next();
             if (item != null && item.peerId.contentEquals(peerId)) {
                 isDiscovered = true;
                 break;
@@ -347,7 +356,7 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
 
     //this is always called in context of thread that created instance of the library
     @Override
-    public ServiceItem CurrentPeersList(List<ServiceItem> serviceItems) {
+    public ServiceItem CurrentPeersList(final List<ServiceItem> serviceItems) {
 
         Boolean wasPreviouslyAvailable = false;
 
@@ -358,7 +367,9 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
                 if(item != null) {
                     wasPreviouslyAvailable = false;
 
-                    for (ServiceItem lastItem : lastAvailableList) {
+                    Iterator<ServiceItem> iterator = lastAvailableList.iterator();
+                    while (iterator.hasNext()) {
+                        ServiceItem lastItem = iterator.next();
                         if (lastItem != null && item.deviceAddress.equalsIgnoreCase(lastItem.deviceAddress)) {
                             wasPreviouslyAvailable = true;
                             lastAvailableList.remove(lastItem);
@@ -372,7 +383,9 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
             }
         }
 
-        for (ServiceItem lastItem2: lastAvailableList) {
+        Iterator<ServiceItem> iterator2 = lastAvailableList.iterator();
+        while (iterator2.hasNext()) {
+            ServiceItem lastItem2 = iterator2.next();
             jsonArray.put(getAvailabilityStatus(lastItem2, false));
             lastAvailableList.remove(lastItem2);
         }
@@ -399,7 +412,9 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
     public void PeerDiscovered(ServiceItem serviceItem) {
         boolean wasPrevouslyAvailable = false;
 
-        for (ServiceItem lastItem : lastAvailableList) {
+        Iterator<ServiceItem> iterator = lastAvailableList.iterator();
+        while (iterator.hasNext()) {
+            ServiceItem lastItem = iterator.next();
             if (lastItem != null && serviceItem.deviceAddress.equalsIgnoreCase(lastItem.deviceAddress)) {
                 wasPrevouslyAvailable = true;
             }

--- a/src/android/java/io/jxcore/node/BtConnectorHelper.java
+++ b/src/android/java/io/jxcore/node/BtConnectorHelper.java
@@ -14,7 +14,6 @@ import org.thaliproject.p2p.btconnectorlib.BTConnector;
 import org.thaliproject.p2p.btconnectorlib.BTConnectorSettings;
 import org.thaliproject.p2p.btconnectorlib.ServiceItem;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -114,9 +113,7 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
     public boolean  DisconnectIncomingConnections() {
 
         boolean ret = false;
-        Iterator<BtToServerSocket> iterator = mServerSocketList.iterator();
-        while (iterator.hasNext()) {
-            BtToServerSocket rSocket = iterator.next();
+        for (BtToServerSocket rSocket : mServerSocketList) {
             if (rSocket != null) {
                 print_debug("Disconnect:::Stop : mBtToServerSocket :" + rSocket.getName());
                 rSocket.Stop();
@@ -155,9 +152,7 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
 
         ServiceItem selectedDevice = null;
 
-        Iterator<ServiceItem> iterator = lastAvailableList.iterator();
-        while (iterator.hasNext()) {
-            ServiceItem item = iterator.next();
+        for (ServiceItem item : lastAvailableList) {
             if (item != null && item.peerId.contentEquals(toPeerId)) {
                 selectedDevice = item;
                 break;
@@ -175,17 +170,25 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
             return;
         }
 
-        BTConnector.TryConnectReturnValues retVal = tmpConn.TryConnect(selectedDevice);
-        if (retVal == BTConnector.TryConnectReturnValues.Connecting) {
-            //all is ok, lets wait callbacks, and for them lets copy the callback here
-            mConnectStatusCallback = connectStatusCallback;
-        } else if (retVal == BTConnector.TryConnectReturnValues.NoSelectedDevice) {
-            // we do check this already, thus we should not get this ever.
-            connectStatusCallback.ConnectionStatusUpdate("Device Address for " + toPeerId + " not found from Discovered device list.", -1);
-        } else if (retVal == BTConnector.TryConnectReturnValues.AlreadyAttemptingToConnect) {
-            connectStatusCallback.ConnectionStatusUpdate("There is already one connection attempt progressing.", -1);
-        } else if (retVal == BTConnector.TryConnectReturnValues.BTDeviceFetchFailed) {
-            connectStatusCallback.ConnectionStatusUpdate("Bluetooth API failed to get Bluetooth device for the address : " + selectedDevice.peerAddress, -1);
+        switch(tmpConn.TryConnect(selectedDevice)){
+            case Connecting:{
+                //all is ok, lets wait callbacks, and for them lets copy the callback here
+                mConnectStatusCallback = connectStatusCallback;
+            }
+            break;
+            case  NoSelectedDevice:{
+                // we do check this already, thus we should not get this ever.
+                connectStatusCallback.ConnectionStatusUpdate("Device Address for " + toPeerId + " not found from Discovered device list.", -1);
+            }
+            break;
+            case  AlreadyAttemptingToConnect:{
+                connectStatusCallback.ConnectionStatusUpdate("There is already one connection attempt progressing.", -1);
+            }
+            break;
+            case  BTDeviceFetchFailed:{
+                connectStatusCallback.ConnectionStatusUpdate("Bluetooth API failed to get Bluetooth device for the address : " + selectedDevice.peerAddress, -1);
+            }
+            break;
         }
     }
 
@@ -271,9 +274,7 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
 
         print_debug("BT Disconnected with error : " + Error);
 
-        Iterator<BtToServerSocket> iterator = mServerSocketList.iterator();
-        while (iterator.hasNext()) {
-            BtToServerSocket rSocket = iterator.next();
+        for (BtToServerSocket rSocket : mServerSocketList) {
             if (rSocket != null && (rSocket.getId() == who.getId())) {
                 print_debug("Disconnect:::Stop : mBtToServerSocket :" + rSocket.GetPeerName());
                 rSocket.Stop();
@@ -289,9 +290,7 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
 
         boolean isDiscovered = false;
 
-        Iterator<ServiceItem> iterator = lastAvailableList.iterator();
-        while (iterator.hasNext()) {
-            ServiceItem item = iterator.next();
+        for (ServiceItem item : lastAvailableList) {
             if (item != null && item.peerId.contentEquals(peerId)) {
                 isDiscovered = true;
                 break;
@@ -367,9 +366,7 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
                 if(item != null) {
                     wasPreviouslyAvailable = false;
 
-                    Iterator<ServiceItem> iterator = lastAvailableList.iterator();
-                    while (iterator.hasNext()) {
-                        ServiceItem lastItem = iterator.next();
+                    for (ServiceItem lastItem : lastAvailableList) {
                         if (lastItem != null && item.deviceAddress.equalsIgnoreCase(lastItem.deviceAddress)) {
                             wasPreviouslyAvailable = true;
                             lastAvailableList.remove(lastItem);
@@ -383,9 +380,7 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
             }
         }
 
-        Iterator<ServiceItem> iterator2 = lastAvailableList.iterator();
-        while (iterator2.hasNext()) {
-            ServiceItem lastItem2 = iterator2.next();
+        for (ServiceItem lastItem2 : lastAvailableList) {
             jsonArray.put(getAvailabilityStatus(lastItem2, false));
             lastAvailableList.remove(lastItem2);
         }
@@ -412,9 +407,7 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
     public void PeerDiscovered(ServiceItem serviceItem) {
         boolean wasPrevouslyAvailable = false;
 
-        Iterator<ServiceItem> iterator = lastAvailableList.iterator();
-        while (iterator.hasNext()) {
-            ServiceItem lastItem = iterator.next();
+        for (ServiceItem lastItem : lastAvailableList) {
             if (lastItem != null && serviceItem.deviceAddress.equalsIgnoreCase(lastItem.deviceAddress)) {
                 wasPrevouslyAvailable = true;
             }

--- a/src/android/java/io/jxcore/node/BtConnectorHelper.java
+++ b/src/android/java/io/jxcore/node/BtConnectorHelper.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class BtConnectorHelper implements BTConnector.Callback, BTConnector.ConnectSelector, BtSocketDisconnectedCallBack {
 
-    private Context context = null;
+    private final Context context;
 
     private final String serviceTypeIdentifier = "Cordovap2p._tcp";
     private final String BtUUID                = "fa87c0d0-afac-11de-8a39-0800200c9a66";
@@ -33,12 +33,11 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
 
     private final CopyOnWriteArrayList<ServiceItem> lastAvailableList = new CopyOnWriteArrayList<ServiceItem>();
 
-    private BTConnectorSettings conSettings = null;
+    private final BTConnectorSettings conSettings;
     private BTConnector mBTConnector = null;
 
     private final CopyOnWriteArrayList<BtToServerSocket> mServerSocketList = new CopyOnWriteArrayList<BtToServerSocket>();
     private BtToRequestSocket mBtToRequestSocket = null;
-
 
     private int mServerPort = 0;
 
@@ -360,7 +359,6 @@ public class BtConnectorHelper implements BTConnector.Callback, BTConnector.Conn
             case Connected:
                 break;
         }
-
     }
 
     // this is called with a full list of peer-services we see, its takes time to get,

--- a/src/android/java/io/jxcore/node/BtSocketDisconnectedCallBack.java
+++ b/src/android/java/io/jxcore/node/BtSocketDisconnectedCallBack.java
@@ -3,6 +3,6 @@ package io.jxcore.node;
 /**
  * Created by juksilve on 29.6.2015.
  */
-public interface BtSocketDisconnectedCallBack {
+interface BtSocketDisconnectedCallBack {
     void Disconnected(Thread who, String Error);
 }

--- a/src/android/java/io/jxcore/node/BtToRequestSocket.java
+++ b/src/android/java/io/jxcore/node/BtToRequestSocket.java
@@ -1,6 +1,8 @@
 package io.jxcore.node;
 
 import android.bluetooth.BluetoothSocket;
+
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
@@ -9,70 +11,28 @@ import java.net.Socket;
 /**
  * Created by juksilve on 4.6.2015.
  */
-public class BtToRequestSocket extends Thread implements StreamCopyingThread.CopyThreadCallback {
-
-    private final BtToRequestSocket that = this;
+public class BtToRequestSocket extends BtToSocketBase{
 
     public interface ReadyForIncoming
     {
         void listeningAndAcceptingNow(int port);
     }
     private final ReadyForIncoming readyCallback;
-    private final BtSocketDisconnectedCallBack mHandler;
-
-    private BluetoothSocket mmSocket = null;
-    private Socket localHostSocket = null;
     private ServerSocket srvSocket = null;
 
-    private InputStream mmInStream = null;
-    private OutputStream mmOutStream = null;
-    private InputStream LocalInputStream = null;
-    private OutputStream LocalOutputStream = null;
-
-    private String mPeerId = "";
-    private String mPeerName = "";
-    private String mPeerAddress = "";
-
-    private StreamCopyingThread SendingThread = null;
-    private StreamCopyingThread ReceivingThread = null;
-
-    private int mHTTPPort = 0;
-
-    private boolean mStopped = false;
-
-    public BtToRequestSocket(BluetoothSocket socket, BtSocketDisconnectedCallBack handler,ReadyForIncoming callback) {
-        print_debug("Creating BtConnectedRequestSocket");
-        mHandler = handler;
-        mmSocket = socket;
+    public BtToRequestSocket(BluetoothSocket socket, BtSocketDisconnectedCallBack handler,ReadyForIncoming callback)  throws IOException {
+        super(socket,handler);
+        print_debug("BtToRequestSocket", "Creating BtConnectedRequestSocket");
         readyCallback = callback;
-
-        InputStream tmpIn = null;
-        OutputStream tmpOut = null;
-
-        // Get the BluetoothSocket input and output streams
-        try {
-            print_debug("Get BT input Streams");
-            tmpIn = mmSocket.getInputStream();
-            tmpOut = mmSocket.getOutputStream();
-        } catch (Exception e) {
-            mStopped = true;
-            print_debug("Creating temp sockets  failed: " + e.toString());
-            mHandler.Disconnected(that,"Creating temp sockets  failed");
-        }
-        mmInStream = tmpIn;
-        mmOutStream = tmpOut;
     }
 
     public void run() {
 
         try {
-            print_debug("start Socket with port: " + mHTTPPort);
-            mHTTPPort = 0; // just to make sure its zero
-            srvSocket = new ServerSocket(mHTTPPort);
-            mHTTPPort = srvSocket.getLocalPort();
-            print_debug("mHTTPPort  set to : " + mHTTPPort);
+            srvSocket = new ServerSocket(0);
+            print_debug("BtToRequestSocket", "mHTTPPort  set to : " + srvSocket.getLocalPort());
         } catch (Exception e) {
-            print_debug("Creating local sockets failed: " + e.toString());
+            print_debug("BtToRequestSocket", "Creating local sockets failed: " + e.toString());
             srvSocket = null;
             mStopped = true;
             mHandler.Disconnected(that, "creating socket failed");
@@ -84,31 +44,31 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
 
         try {
             if (readyCallback != null) {
-                readyCallback.listeningAndAcceptingNow(mHTTPPort);
+                readyCallback.listeningAndAcceptingNow(srvSocket.getLocalPort());
             }
-            print_debug("Now accepting connections");
+            print_debug("BtToRequestSocket", "Now accepting connections");
             Socket tmpSocket = srvSocket.accept();
             CloseSocketAndStreams();
             localHostSocket = tmpSocket;
 
-            print_debug("incoming data from: " + GetLocalHostAddressAsString() + ", port: " + GetLocalHostPort());
+            print_debug("BtToRequestSocket", "incoming data from: " + GetLocalHostAddressAsString() + ", port: " + GetLocalHostPort());
             tmpInputStream = localHostSocket.getInputStream();
             tmpOutputStream = localHostSocket.getOutputStream();
 
         } catch (Exception e) {
             mStopped = true;
-            print_debug("Creating local streams failed: " + e.toString());
+            print_debug("BtToRequestSocket", "Creating local streams failed: " + e.toString());
             mHandler.Disconnected(that, "Creating local streams failed");
             return;
         }
 
-        print_debug("Set local streams");
+        print_debug("BtToRequestSocket", "Set local streams");
         LocalInputStream = tmpInputStream;
         LocalOutputStream = tmpOutputStream;
 
         if (mmInStream == null || LocalInputStream == null || mmOutStream == null || LocalOutputStream == null || localHostSocket == null) {
             mStopped = true;
-            print_debug("at least one stream is null");
+            print_debug("BtToRequestSocket", "at least one stream is null");
             mHandler.Disconnected(that, "at least one stream is null");
             return;
         }
@@ -121,133 +81,22 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
         ReceivingThread.setDebugTag("--Receiving");
         ReceivingThread.start();
 
-        print_debug("rin ended ---------------------------;");
-    }
-
-    @Override
-    public void StreamCopyError(StreamCopyingThread who, String error) {
-        // Receiving Thread is the one that is having Bluetooth input stream,
-        // thus if it gives error, we know that connection has been disconnected from other end.
-        if(who == ReceivingThread){
-            print_debug("ReceivingThread thread got error: " + error);
-            mStopped = true;
-            mHandler.Disconnected(that,"creating serve socket failed");
-        }else if(who == SendingThread){
-            //Sending socket has local input stream, thus if it is giving error we are getting local disconnection
-            // thus we should do round to get new local connection
-            print_debug("SendingThread thread got error: " + error);
-            if(SendingThread != null){
-                print_debug("Stop SendingThread");
-                SendingThread.Stop();
-                SendingThread = null;
-            }
-            mStopped = true;
-            // with this app we want to disconnect the Bluetooth once we lose local sockets
-            mHandler.Disconnected(that,error);
-
-        }else{
-            print_debug("Dunno which thread got error: " + error);
-        }
+        print_debug("BtToRequestSocket", "rin ended ---------------------------;");
     }
 
     private  int GetLocalHostPort() {
-        return mHTTPPort;
-    }
-
-    private String GetLocalHostAddressAsString() {
-        return localHostSocket == null || localHostSocket.getInetAddress() == null ? null : localHostSocket.getInetAddress().toString();
+        return srvSocket == null ? 0 : srvSocket.getLocalPort();
     }
 
     public void Stop() {
-        mStopped = true;
-
-        StreamCopyingThread tmpSCTrec = ReceivingThread;
-        ReceivingThread = null;
-        if(tmpSCTrec != null){
-            print_debug("Stop ReceivingThread");
-            tmpSCTrec.Stop();
-        }
-
-        StreamCopyingThread tmpSCTsend = SendingThread;
-        SendingThread = null;
-        if(tmpSCTsend != null){
-            print_debug("Stop SendingThread");
-            tmpSCTsend.Stop();
-        }
-
-        CloseSocketAndStreams();
-
-        InputStream tmpInStr = mmInStream;
-        mmInStream = null;
-        if (tmpInStr != null) {
-            try {print_debug("Close bt in");
-                tmpInStr.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
-        }
-
-        OutputStream tmpOutStr = mmOutStream;
-        mmOutStream = null;
-        if (tmpOutStr != null) {
-            try {print_debug("Close bt out");
-                tmpOutStr.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
-        }
-
-        BluetoothSocket tmpSoc = mmSocket;
-        mmSocket = null;
-        if (tmpSoc != null) {
-            try {print_debug("Close bt socket");
-                tmpSoc.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
-        }
+        super.Stop();
 
         ServerSocket tmpSrvSoc = srvSocket;
         srvSocket = null;
         if (tmpSrvSoc != null) {
-            try {print_debug("Close server socket");
-                tmpSrvSoc.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
+            try {print_debug("BtToRequestSocket", "Close server socket");
+                tmpSrvSoc.close();} catch (Exception e) {print_debug("BtToRequestSocket", "Close error : " + e.toString());}
         }
-    }
-
-    private  void CloseSocketAndStreams() {
-
-        InputStream tmpLocStrIn = LocalInputStream;
-        LocalInputStream = null;
-        if (tmpLocStrIn != null) {
-            try {print_debug("Close local in");
-                tmpLocStrIn.close();} catch (Exception e) {
-                print_debug("Close error : " + e.toString());
-            }
-        }
-
-        OutputStream tmpLocStrOut = LocalOutputStream;
-        LocalOutputStream = null;
-        if (tmpLocStrOut != null) {
-            try {print_debug("Close LocalOutputStream");
-                tmpLocStrOut.close();} catch (Exception e) {
-                print_debug("Close error : " + e.toString());
-            }
-        }
-
-        Socket tmpLHSoc = localHostSocket;
-        localHostSocket = null;
-        if (tmpLHSoc != null) {
-            try {print_debug("Close localHostSocket");
-                tmpLHSoc.close();} catch (Exception e) {
-                print_debug("Close error : " + e.toString());
-            }
-        }
-    }
-    public void SetIdAddressAndName(String peerId,String peerName,String peerAddress) {
-        mPeerId = peerId;
-        mPeerName = peerName;
-        mPeerAddress = peerAddress;
-    }
-    public String GetPeerId() {
-        return mPeerId;
-    }
-    public String GetPeerName(){return mPeerName;}
-    public String GetPeerAddress(){return mPeerAddress;}
-
-    private  void print_debug(String message){
-        //Log.i(TAG, message);
     }
 
 }

--- a/src/android/java/io/jxcore/node/BtToRequestSocket.java
+++ b/src/android/java/io/jxcore/node/BtToRequestSocket.java
@@ -1,8 +1,6 @@
 package io.jxcore.node;
 
 import android.bluetooth.BluetoothSocket;
-import android.os.Handler;
-import android.util.Log;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
@@ -13,14 +11,14 @@ import java.net.Socket;
  */
 public class BtToRequestSocket extends Thread implements StreamCopyingThread.CopyThreadCallback {
 
-    BtToRequestSocket that = this;
+    private final BtToRequestSocket that = this;
 
     public interface ReadyForIncoming
     {
         void listeningAndAcceptingNow(int port);
     }
-    private ReadyForIncoming readyCallback;
-    private BtSocketDisconnectedCallBack mHandler;
+    private final ReadyForIncoming readyCallback;
+    private final BtSocketDisconnectedCallBack mHandler;
 
     private BluetoothSocket mmSocket = null;
     private Socket localHostSocket = null;
@@ -40,9 +38,7 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
 
     private int mHTTPPort = 0;
 
-    final String TAG = "--BtCon-CLIENT-Socket";
-
-    boolean mStopped = false;
+    private boolean mStopped = false;
 
     public BtToRequestSocket(BluetoothSocket socket, BtSocketDisconnectedCallBack handler,ReadyForIncoming callback) {
         print_debug("Creating BtConnectedRequestSocket");
@@ -67,13 +63,10 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
         mmOutStream = tmpOut;
     }
 
-    public void setPort(int port) {
-        mHTTPPort = port;
-    }
-
     public void run() {
         try {
             print_debug("start Socket with port: " + mHTTPPort);
+            mHTTPPort = 0; // just to make sure its zero
             srvSocket = new ServerSocket(mHTTPPort);
             mHTTPPort = srvSocket.getLocalPort();
             print_debug("mHTTPPort  set to : " + mHTTPPort);
@@ -96,7 +89,7 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
                 CloseSocketAndStreams();
                 localHostSocket = tmpSocket;
 
-                print_debug("incoming data from: " + GetLocalHostAddress() + ", port: " + GetLocalHostPort());
+                print_debug("incoming data from: " + GetLocalHostAddressAsString() + ", port: " + GetLocalHostPort());
                 tmpInputStream = localHostSocket.getInputStream();
                 tmpOutputStream = localHostSocket.getOutputStream();
 
@@ -165,20 +158,12 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
         }
     }
 
-    public int GetLocalHostPort() {
+    private  int GetLocalHostPort() {
         return mHTTPPort;
     }
 
-    public String GetLocalHostAddress() {
-        if(localHostSocket == null){
-            return "";
-        }
-
-        if(localHostSocket.getInetAddress() == null){
-            return "";
-        }
-
-        return localHostSocket.getInetAddress().toString();
+    private String GetLocalHostAddressAsString() {
+        return localHostSocket == null || localHostSocket.getInetAddress() == null ? null : localHostSocket.getInetAddress().toString();
     }
 
     public void Stop() {
@@ -229,7 +214,7 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
         }
     }
 
-    public void CloseSocketAndStreams() {
+    private  void CloseSocketAndStreams() {
 
         InputStream tmpLocStrIn = LocalInputStream;
         LocalInputStream = null;
@@ -243,7 +228,7 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
         OutputStream tmpLocStrOut = LocalOutputStream;
         LocalOutputStream = null;
         if (tmpLocStrOut != null) {
-            try {print_debug("Close localout");
+            try {print_debug("Close LocalOutputStream");
                 tmpLocStrOut.close();} catch (Exception e) {
                 print_debug("Close error : " + e.toString());
             }
@@ -252,7 +237,7 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
         Socket tmpLHSoc = localHostSocket;
         localHostSocket = null;
         if (tmpLHSoc != null) {
-            try {print_debug("Close local host sokcte");
+            try {print_debug("Close localHostSocket");
                 tmpLHSoc.close();} catch (Exception e) {
                 print_debug("Close error : " + e.toString());
             }
@@ -266,14 +251,10 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
     public String GetPeerId() {
         return mPeerId;
     }
-    public String GetPeerName(){
-        return mPeerName;
-    }
-    public String GetPeerAddress(){
-        return mPeerAddress;
-    }
+    public String GetPeerName(){return mPeerName;}
+    public String GetPeerAddress(){return mPeerAddress;}
 
-    public void print_debug(String message){
+    private  void print_debug(String message){
         //Log.i(TAG, message);
     }
 

--- a/src/android/java/io/jxcore/node/BtToRequestSocket.java
+++ b/src/android/java/io/jxcore/node/BtToRequestSocket.java
@@ -170,77 +170,92 @@ public class BtToRequestSocket extends Thread implements StreamCopyingThread.Cop
     }
 
     public String GetLocalHostAddress() {
-        String ret = "";
-        if(localHostSocket != null && localHostSocket.getInetAddress() != null){
-            ret = localHostSocket.getInetAddress().toString();
+        if(localHostSocket == null){
+            return "";
         }
-        return ret;
+
+        if(localHostSocket.getInetAddress() == null){
+            return "";
+        }
+
+        return localHostSocket.getInetAddress().toString();
     }
 
     public void Stop() {
         mStopped = true;
 
-        if(ReceivingThread != null){
+        StreamCopyingThread tmpSCTrec = ReceivingThread;
+        ReceivingThread = null;
+        if(tmpSCTrec != null){
             print_debug("Stop ReceivingThread");
-            ReceivingThread.Stop();
-            ReceivingThread = null;
+            tmpSCTrec.Stop();
         }
 
-        if(SendingThread != null){
+        StreamCopyingThread tmpSCTsend = SendingThread;
+        SendingThread = null;
+        if(tmpSCTsend != null){
             print_debug("Stop SendingThread");
-            SendingThread.Stop();
-            SendingThread = null;
+            tmpSCTsend.Stop();
         }
 
         CloseSocketAndStreams();
 
-        if (mmInStream != null) {
+        InputStream tmpInStr = mmInStream;
+        mmInStream = null;
+        if (tmpInStr != null) {
             try {print_debug("Close bt in");
-                mmInStream.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
-            mmInStream = null;
+                tmpInStr.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
         }
 
-        if (mmOutStream != null) {
+        OutputStream tmpOutStr = mmOutStream;
+        mmOutStream = null;
+        if (tmpOutStr != null) {
             try {print_debug("Close bt out");
-                mmOutStream.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
-            mmOutStream = null;
+                tmpOutStr.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
         }
 
-        if (mmSocket != null) {
+        BluetoothSocket tmpSoc = mmSocket;
+        mmSocket = null;
+        if (tmpSoc != null) {
             try {print_debug("Close bt socket");
-                mmSocket.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
-            mmSocket = null;
+                tmpSoc.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
         }
 
-        if (srvSocket != null) {
+        ServerSocket tmpSrvSoc = srvSocket;
+        srvSocket = null;
+        if (tmpSrvSoc != null) {
             try {print_debug("Close server socket");
-                srvSocket.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
-            srvSocket = null;
+                tmpSrvSoc.close();} catch (Exception e) {print_debug("Close error : " + e.toString());}
         }
     }
 
     public void CloseSocketAndStreams() {
-        if (LocalInputStream != null) {
+
+        InputStream tmpLocStrIn = LocalInputStream;
+        LocalInputStream = null;
+        if (tmpLocStrIn != null) {
             try {print_debug("Close local in");
-                LocalInputStream.close();} catch (Exception e) {
+                tmpLocStrIn.close();} catch (Exception e) {
                 print_debug("Close error : " + e.toString());
             }
-            LocalInputStream = null;
         }
 
-        if (LocalOutputStream != null) {
+        OutputStream tmpLocStrOut = LocalOutputStream;
+        LocalOutputStream = null;
+        if (tmpLocStrOut != null) {
             try {print_debug("Close localout");
-                LocalOutputStream.close();} catch (Exception e) {
+                tmpLocStrOut.close();} catch (Exception e) {
                 print_debug("Close error : " + e.toString());
             }
-            LocalOutputStream = null;
         }
-        if (localHostSocket != null) {
+
+        Socket tmpLHSoc = localHostSocket;
+        localHostSocket = null;
+        if (tmpLHSoc != null) {
             try {print_debug("Close local host sokcte");
-                localHostSocket.close();} catch (Exception e) {
+                tmpLHSoc.close();} catch (Exception e) {
                 print_debug("Close error : " + e.toString());
             }
-            localHostSocket = null;
         }
     }
     public void SetIdAddressAndName(String peerId,String peerName,String peerAddress) {

--- a/src/android/java/io/jxcore/node/BtToServerSocket.java
+++ b/src/android/java/io/jxcore/node/BtToServerSocket.java
@@ -71,12 +71,10 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
             mLocalHostAddress = (Inet4Address) Inet4Address.getByName("localhost");
             localHostSocket = new Socket(mLocalHostAddress, mHTTPPort);
 
-            if(localHostSocket != null){
-                mHTTPPort = localHostSocket.getPort();
-            }
+            mHTTPPort = localHostSocket.getPort();
+
             print_debug("LocalHost addr: " + GetLocalHostAddress() + ", port: " + GetLocalHostPort());
 
-            print_debug("Get local streams");
             tmpInputStream = localHostSocket.getInputStream();
             tmpOutputStream = localHostSocket.getOutputStream();
 
@@ -142,55 +140,69 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
     }
 
     public String GetLocalHostAddress() {
-        String ret = "";
-        if(localHostSocket != null && localHostSocket.getInetAddress() != null){
-            ret = localHostSocket.getInetAddress().toString();
+
+        if(localHostSocket == null){
+            return "";
         }
-        return ret;
+
+        if(localHostSocket.getInetAddress() == null){
+            return "";
+        }
+
+        return localHostSocket.getInetAddress().toString();
     }
 
     public void Stop() {
         mStopped = true;
 
-        if(ReceivingThread != null){
+        StreamCopyingThread tmpSCTrec = ReceivingThread;
+        ReceivingThread = null;
+        if(tmpSCTrec != null){
             print_debug("Stop ReceivingThread");
-            ReceivingThread.Stop();
-            ReceivingThread = null;
+            tmpSCTrec.Stop();
         }
 
-        if(SendingThread != null){
+        StreamCopyingThread tmpSCTsend = SendingThread;
+        SendingThread = null;
+        if(tmpSCTsend != null){
             print_debug("Stop SendingThread");
-            SendingThread.Stop();
-            SendingThread = null;
+            tmpSCTsend.Stop();
         }
 
-        if (mmInStream != null) {
-            try {mmInStream.close();} catch (Exception e) {}
-            mmInStream = null;
+        InputStream tmpinStr = mmInStream;
+        mmInStream = null;
+        if (tmpinStr != null) {
+            try {tmpinStr.close();} catch (Exception e) {}
         }
 
-        if (LocalInputStream != null) {
-            try {LocalInputStream.close();} catch (Exception e) {}
-            LocalInputStream = null;
+        InputStream tmpinStrLoc = LocalInputStream;
+        LocalInputStream = null;
+        if (tmpinStrLoc != null) {
+            try {tmpinStrLoc.close();} catch (Exception e) {}
         }
 
-        if (LocalOutputStream != null) {
-            try {LocalOutputStream.close();} catch (Exception e) {}
-            LocalOutputStream = null;
+        OutputStream tmpoutStrLoc = LocalOutputStream;
+        LocalOutputStream = null;
+        if (tmpoutStrLoc != null) {
+            try {tmpoutStrLoc.close();} catch (Exception e) {}
         }
 
-        if (mmOutStream != null) {
-            try {mmOutStream.close();} catch (Exception e) {}
-            mmOutStream = null;
+        OutputStream tmpoutStr = mmOutStream;
+        mmOutStream = null;
+        if (tmpoutStr != null) {
+            try {tmpoutStr.close();} catch (Exception e) {}
         }
 
-        if (mmSocket != null) {
-            try {mmSocket.close();} catch (Exception e) {}
-            mmSocket = null;
+        BluetoothSocket tmpbtSoc = mmSocket;
+        mmSocket = null;
+        if (tmpbtSoc != null) {
+            try {tmpbtSoc.close();} catch (Exception e) {}
         }
-        if (localHostSocket != null) {
-            try {localHostSocket.close();} catch (Exception e) {}
-            localHostSocket = null;
+
+        Socket tmplhSoc = localHostSocket;
+        localHostSocket = null;
+        if (tmplhSoc != null) {
+            try {tmplhSoc.close();} catch (Exception e) {}
         }
     }
 

--- a/src/android/java/io/jxcore/node/BtToServerSocket.java
+++ b/src/android/java/io/jxcore/node/BtToServerSocket.java
@@ -11,7 +11,7 @@ import java.net.Socket;
 /**
  * Created by juksilve on 15.5.2015.
  */
-public class BtToServerSocket extends BtToSocketBase {
+class BtToServerSocket extends BtToSocketBase {
 
     private int mHTTPPort = 0;
 

--- a/src/android/java/io/jxcore/node/BtToServerSocket.java
+++ b/src/android/java/io/jxcore/node/BtToServerSocket.java
@@ -13,28 +13,25 @@ import java.net.Socket;
  */
 public class BtToServerSocket extends Thread implements StreamCopyingThread.CopyThreadCallback {
 
-    BtToServerSocket that = this;
-    private BluetoothSocket mmSocket = null;;
+    private final BtToServerSocket that = this;
+    private BluetoothSocket mmSocket = null;
     private Socket localHostSocket = null;
 
     private InputStream mmInStream = null;
     private OutputStream mmOutStream = null;
     private InputStream LocalInputStream = null;
     private OutputStream LocalOutputStream = null;
-    private BtSocketDisconnectedCallBack mHandler;
+    private final BtSocketDisconnectedCallBack mHandler;
     private String mPeerId = "";
     private String mPeerName = "";
     private String mPeerAddress = "";
 
     private StreamCopyingThread SendingThread = null;
     private StreamCopyingThread ReceivingThread = null;
-    private Inet4Address mLocalHostAddress = null;
-
-    final String TAG  = "BTConnectedThread";
 
     private int mHTTPPort = 0;
 
-    boolean mStopped = false;
+    private boolean mStopped = false;
 
     public BtToServerSocket(BluetoothSocket socket, BtSocketDisconnectedCallBack handler) {
         print_debug("Creating BTConnectedThread");
@@ -68,12 +65,12 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
         InputStream tmpInputStream = null;
         OutputStream tmpOutputStream = null;
         try {
-            mLocalHostAddress = (Inet4Address) Inet4Address.getByName("localhost");
+            Inet4Address mLocalHostAddress = (Inet4Address) Inet4Address.getByName("localhost");
             localHostSocket = new Socket(mLocalHostAddress, mHTTPPort);
 
             mHTTPPort = localHostSocket.getPort();
 
-            print_debug("LocalHost addr: " + GetLocalHostAddress() + ", port: " + GetLocalHostPort());
+            print_debug("LocalHost address: " + GetLocalHostAddressAsString() + ", port: " + GetLocalHostPort());
 
             tmpInputStream = localHostSocket.getInputStream();
             tmpOutputStream = localHostSocket.getOutputStream();
@@ -122,10 +119,11 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
         //Sending socket has local input stream, thus if it is giving error we are getting local disconnection
         // thus we should do round to get new local connection
             print_debug("SendingThread thread got error: " + error);
-            if(SendingThread != null){
+            StreamCopyingThread tmpSendThread = SendingThread;
+            SendingThread = null;
+            if(tmpSendThread != null){
                 print_debug("Stop SendingThread");
-                SendingThread.Stop();
-                SendingThread = null;
+                tmpSendThread.Stop();
             }
 
             mStopped = true;
@@ -139,17 +137,8 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
         return mHTTPPort;
     }
 
-    public String GetLocalHostAddress() {
-
-        if(localHostSocket == null){
-            return "";
-        }
-
-        if(localHostSocket.getInetAddress() == null){
-            return "";
-        }
-
-        return localHostSocket.getInetAddress().toString();
+    private String GetLocalHostAddressAsString() {
+        return localHostSocket == null || localHostSocket.getInetAddress() == null ? null : localHostSocket.getInetAddress().toString();
     }
 
     public void Stop() {
@@ -172,37 +161,37 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
         InputStream tmpinStr = mmInStream;
         mmInStream = null;
         if (tmpinStr != null) {
-            try {tmpinStr.close();} catch (Exception e) {}
+            try {tmpinStr.close();} catch (Exception e) {e.printStackTrace();}
         }
 
         InputStream tmpinStrLoc = LocalInputStream;
         LocalInputStream = null;
         if (tmpinStrLoc != null) {
-            try {tmpinStrLoc.close();} catch (Exception e) {}
+            try {tmpinStrLoc.close();} catch (Exception e) {e.printStackTrace();}
         }
 
         OutputStream tmpoutStrLoc = LocalOutputStream;
         LocalOutputStream = null;
         if (tmpoutStrLoc != null) {
-            try {tmpoutStrLoc.close();} catch (Exception e) {}
+            try {tmpoutStrLoc.close();} catch (Exception e) {e.printStackTrace();}
         }
 
         OutputStream tmpoutStr = mmOutStream;
         mmOutStream = null;
         if (tmpoutStr != null) {
-            try {tmpoutStr.close();} catch (Exception e) {}
+            try {tmpoutStr.close();} catch (Exception e) {e.printStackTrace();}
         }
 
         BluetoothSocket tmpbtSoc = mmSocket;
         mmSocket = null;
         if (tmpbtSoc != null) {
-            try {tmpbtSoc.close();} catch (Exception e) {}
+            try {tmpbtSoc.close();} catch (Exception e) {e.printStackTrace();}
         }
 
         Socket tmplhSoc = localHostSocket;
         localHostSocket = null;
         if (tmplhSoc != null) {
-            try {tmplhSoc.close();} catch (Exception e) {}
+            try {tmplhSoc.close();} catch (Exception e) {e.printStackTrace();}
         }
     }
 
@@ -211,18 +200,14 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
         mPeerName = peerName;
         mPeerAddress = peerAddress;
     }
-    public String GetPeerId() {
-        return mPeerId;
-    }
+    public String GetPeerId() {return mPeerId;}
     public String GetPeerName(){
         return mPeerName;
     }
-    public String GetPeerAddress(){
-            return mPeerAddress;
-    }
+    public String GetPeerAddress(){return mPeerAddress;}
 
-    public void print_debug(String message){
-        Log.i(TAG, message);
+    private void print_debug(String message){
+        Log.i("BTConnectedThread", message);
     }
 
 

--- a/src/android/java/io/jxcore/node/BtToServerSocket.java
+++ b/src/android/java/io/jxcore/node/BtToServerSocket.java
@@ -1,8 +1,8 @@
 package io.jxcore.node;
 
 import android.bluetooth.BluetoothSocket;
-import android.util.Log;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Inet4Address;
@@ -11,32 +11,13 @@ import java.net.Socket;
 /**
  * Created by juksilve on 15.5.2015.
  */
-public class BtToServerSocket extends Thread implements StreamCopyingThread.CopyThreadCallback {
-
-    private final BtToServerSocket that = this;
-    private BluetoothSocket mmSocket = null;
-    private Socket localHostSocket = null;
-
-    private InputStream mmInStream = null;
-    private OutputStream mmOutStream = null;
-    private InputStream LocalInputStream = null;
-    private OutputStream LocalOutputStream = null;
-    private final BtSocketDisconnectedCallBack mHandler;
-    private String mPeerId = "";
-    private String mPeerName = "";
-    private String mPeerAddress = "";
-
-    private StreamCopyingThread SendingThread = null;
-    private StreamCopyingThread ReceivingThread = null;
+public class BtToServerSocket extends BtToSocketBase {
 
     private int mHTTPPort = 0;
 
-    private boolean mStopped = false;
-
-    public BtToServerSocket(BluetoothSocket socket, BtSocketDisconnectedCallBack handler) {
-        print_debug("Creating BTConnectedThread");
-        mHandler = handler;
-        mmSocket = socket;
+    public BtToServerSocket(BluetoothSocket socket, BtSocketDisconnectedCallBack handler) throws IOException{
+        super(socket,handler);
+        print_debug("BtToRequestSocket", "Creating BTConnectedThread");
     }
 
     public void setPort(int port){
@@ -45,25 +26,7 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
 
     public void run() {
 
-        print_debug("--DoOneRunRound started");
-
-        InputStream tmpIn = null;
-        OutputStream tmpOut = null;
-
-        // Get the BluetoothSocket input and output streams
-        try {
-            print_debug("Get BT input Streams");
-            tmpIn = mmSocket.getInputStream();
-            tmpOut = mmSocket.getOutputStream();
-        } catch (Exception e) {
-            print_debug("Creating Bluetooth input streams failed: " + e.toString());
-            mStopped = true;
-            mHandler.Disconnected(that,"creating Bluetooth input streams failed");
-            return;
-        }
-
-        mmInStream = tmpIn;
-        mmOutStream = tmpOut;
+        print_debug("BtToRequestSocket", "--DoOneRunRound started");
 
         InputStream tmpInputStream = null;
         OutputStream tmpOutputStream = null;
@@ -71,15 +34,13 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
             Inet4Address mLocalHostAddress = (Inet4Address) Inet4Address.getByName("localhost");
             localHostSocket = new Socket(mLocalHostAddress, mHTTPPort);
 
-            mHTTPPort = localHostSocket.getPort();
-
-            print_debug("LocalHost address: " + GetLocalHostAddressAsString() + ", port: " + GetLocalHostPort());
+            print_debug("BtToRequestSocket", "LocalHost address: " + GetLocalHostAddressAsString() + ", port: " + GetLocalHostPort());
 
             tmpInputStream = localHostSocket.getInputStream();
             tmpOutputStream = localHostSocket.getOutputStream();
 
         } catch (Exception e) {
-            print_debug("Creating local input streams failed: " + e.toString());
+            print_debug("BtToRequestSocket", "Creating local input streams failed: " + e.toString());
             mStopped = true;
             mHandler.Disconnected(that, "creating local input streams failed");
             return;
@@ -90,7 +51,7 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
 
         if (mmInStream == null || LocalInputStream == null || mmOutStream == null || LocalOutputStream == null || localHostSocket == null) {
             mStopped = true;
-            print_debug("at least one stream is null");
+            print_debug("BtToRequestSocket", "at least one stream is null");
             mHandler.Disconnected(that, "at least one stream is null");
             return;
         }
@@ -103,113 +64,10 @@ public class BtToServerSocket extends Thread implements StreamCopyingThread.Copy
         ReceivingThread.setDebugTag("--Receiving");
         ReceivingThread.start();
 
-        print_debug("--DoOneRunRound ended");
-    }
-
-    @Override
-    public void StreamCopyError(StreamCopyingThread who, String error) {
-
-        // Receiving Thread is the one that is having Bluetooth input stream,
-        // thus if it gives error, we know that connection has been disconnected from other end.
-        if(who == ReceivingThread){
-            print_debug("ReceivingThread thread got error: " + error);
-            mStopped = true;
-            mHandler.Disconnected(that,"creating serve socket failed");
-        }else if(who == SendingThread){
-        //Sending socket has local input stream, thus if it is giving error we are getting local disconnection
-        // thus we should do round to get new local connection
-            print_debug("SendingThread thread got error: " + error);
-            StreamCopyingThread tmpSendThread = SendingThread;
-            SendingThread = null;
-            if(tmpSendThread != null){
-                print_debug("Stop SendingThread");
-                tmpSendThread.Stop();
-            }
-
-            mStopped = true;
-            mHandler.Disconnected(that,"creating serve socket failed");
-        }else{
-            print_debug("Dunno which thread got error: " + error);
-        }
+        print_debug("BtToRequestSocket", "--DoOneRunRound ended");
     }
 
     public int GetLocalHostPort() {
-        return mHTTPPort;
+        return localHostSocket == null ? 0 : localHostSocket.getPort();
     }
-
-    private String GetLocalHostAddressAsString() {
-        return localHostSocket == null || localHostSocket.getInetAddress() == null ? null : localHostSocket.getInetAddress().toString();
-    }
-
-    public void Stop() {
-        mStopped = true;
-
-        StreamCopyingThread tmpSCTrec = ReceivingThread;
-        ReceivingThread = null;
-        if(tmpSCTrec != null){
-            print_debug("Stop ReceivingThread");
-            tmpSCTrec.Stop();
-        }
-
-        StreamCopyingThread tmpSCTsend = SendingThread;
-        SendingThread = null;
-        if(tmpSCTsend != null){
-            print_debug("Stop SendingThread");
-            tmpSCTsend.Stop();
-        }
-
-        InputStream tmpinStr = mmInStream;
-        mmInStream = null;
-        if (tmpinStr != null) {
-            try {tmpinStr.close();} catch (Exception e) {e.printStackTrace();}
-        }
-
-        InputStream tmpinStrLoc = LocalInputStream;
-        LocalInputStream = null;
-        if (tmpinStrLoc != null) {
-            try {tmpinStrLoc.close();} catch (Exception e) {e.printStackTrace();}
-        }
-
-        OutputStream tmpoutStrLoc = LocalOutputStream;
-        LocalOutputStream = null;
-        if (tmpoutStrLoc != null) {
-            try {tmpoutStrLoc.close();} catch (Exception e) {e.printStackTrace();}
-        }
-
-        OutputStream tmpoutStr = mmOutStream;
-        mmOutStream = null;
-        if (tmpoutStr != null) {
-            try {tmpoutStr.close();} catch (Exception e) {e.printStackTrace();}
-        }
-
-        BluetoothSocket tmpbtSoc = mmSocket;
-        mmSocket = null;
-        if (tmpbtSoc != null) {
-            try {tmpbtSoc.close();} catch (Exception e) {e.printStackTrace();}
-        }
-
-        Socket tmplhSoc = localHostSocket;
-        localHostSocket = null;
-        if (tmplhSoc != null) {
-            try {tmplhSoc.close();} catch (Exception e) {e.printStackTrace();}
-        }
-    }
-
-    public void SetIdAddressAndName(String peerId,String peerName,String peerAddress) {
-        mPeerId = peerId;
-        mPeerName = peerName;
-        mPeerAddress = peerAddress;
-    }
-    public String GetPeerId() {return mPeerId;}
-    public String GetPeerName(){
-        return mPeerName;
-    }
-    public String GetPeerAddress(){return mPeerAddress;}
-
-    private void print_debug(String message){
-        Log.i("BTConnectedThread", message);
-    }
-
-
-
 }

--- a/src/android/java/io/jxcore/node/BtToSocketBase.java
+++ b/src/android/java/io/jxcore/node/BtToSocketBase.java
@@ -1,0 +1,153 @@
+package io.jxcore.node;
+
+import android.bluetooth.BluetoothSocket;
+import android.util.Log;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+
+/**
+ * Created by juksilve on 25.8.2015.
+ */
+public class BtToSocketBase extends Thread implements StreamCopyingThread.CopyThreadCallback  {
+
+    BtToSocketBase that = this;
+    protected final BtSocketDisconnectedCallBack mHandler;
+
+    protected BluetoothSocket mmSocket = null;
+    protected Socket localHostSocket = null;
+
+    protected InputStream mmInStream = null;
+    protected OutputStream mmOutStream = null;
+    protected InputStream LocalInputStream = null;
+    protected OutputStream LocalOutputStream = null;
+
+    private String mPeerId = "";
+    private String mPeerName = "";
+    private String mPeerAddress = "";
+
+    protected StreamCopyingThread SendingThread = null;
+    protected StreamCopyingThread ReceivingThread = null;
+
+    protected volatile boolean mStopped = false;
+
+    public BtToSocketBase(BluetoothSocket socket, BtSocketDisconnectedCallBack handler) throws IOException {
+        print_debug("BtToSocketBase","BtToSocketBase BtConnectedRequestSocket");
+        mHandler = handler;
+        mmSocket = socket;
+        mmInStream = mmSocket.getInputStream();
+        mmOutStream = mmSocket.getOutputStream();
+    }
+
+    @Override
+    public void StreamCopyError(StreamCopyingThread who, String error) {
+        // Receiving Thread is the one that is having Bluetooth input stream,
+        // thus if it gives error, we know that connection has been disconnected from other end.
+        if(who == ReceivingThread){
+            print_debug("BtToSocketBase","ReceivingThread thread got error: " + error);
+            mStopped = true;
+            mHandler.Disconnected(that,"creating serve socket failed");
+        }else if(who == SendingThread){
+            //Sending socket has local input stream, thus if it is giving error we are getting local disconnection
+            // thus we should do round to get new local connection
+            print_debug("BtToSocketBase","SendingThread thread got error: " + error);
+            mStopped = true;
+            // with this app we want to disconnect the Bluetooth once we lose local sockets
+            mHandler.Disconnected(that,error);
+        }else{
+            print_debug("BtToSocketBase","Dunno which thread got error: " + error);
+            mHandler.Disconnected(that,error);
+        }
+    }
+
+    public String GetLocalHostAddressAsString() {
+        return localHostSocket == null || localHostSocket.getInetAddress() == null ? null : localHostSocket.getInetAddress().toString();
+    }
+
+    public void Stop() {
+        mStopped = true;
+
+        StreamCopyingThread tmpSCTrec = ReceivingThread;
+        ReceivingThread = null;
+        if(tmpSCTrec != null){
+            print_debug("BtToSocketBase","Stop ReceivingThread");
+            tmpSCTrec.Stop();
+        }
+
+        StreamCopyingThread tmpSCTsend = SendingThread;
+        SendingThread = null;
+        if(tmpSCTsend != null){
+            print_debug("BtToSocketBase","Stop SendingThread");
+            tmpSCTsend.Stop();
+        }
+
+        CloseSocketAndStreams();
+
+        InputStream tmpInStr = mmInStream;
+        mmInStream = null;
+        if (tmpInStr != null) {
+            try {print_debug("BtToSocketBase","Close bt in");
+                tmpInStr.close();} catch (Exception e) {print_debug("BtToSocketBase","Close error : " + e.toString());}
+        }
+
+        OutputStream tmpOutStr = mmOutStream;
+        mmOutStream = null;
+        if (tmpOutStr != null) {
+            try {print_debug("BtToSocketBase","Close bt out");
+                tmpOutStr.close();} catch (Exception e) {print_debug("BtToSocketBase","Close error : " + e.toString());}
+        }
+
+        BluetoothSocket tmpSoc = mmSocket;
+        mmSocket = null;
+        if (tmpSoc != null) {
+            try {print_debug("BtToSocketBase","Close bt socket");
+                tmpSoc.close();} catch (Exception e) {print_debug("BtToSocketBase","Close error : " + e.toString());}
+        }
+    }
+
+    protected  void CloseSocketAndStreams() {
+
+        InputStream tmpLocStrIn = LocalInputStream;
+        LocalInputStream = null;
+        if (tmpLocStrIn != null) {
+            try {print_debug("BtToSocketBase","Close local in");
+                tmpLocStrIn.close();} catch (Exception e) {
+                print_debug("BtToSocketBase","Close error : " + e.toString());
+            }
+        }
+
+        OutputStream tmpLocStrOut = LocalOutputStream;
+        LocalOutputStream = null;
+        if (tmpLocStrOut != null) {
+            try {print_debug("BtToSocketBase","Close LocalOutputStream");
+                tmpLocStrOut.close();} catch (Exception e) {
+                print_debug("BtToSocketBase","Close error : " + e.toString());
+            }
+        }
+
+        Socket tmpLHSoc = localHostSocket;
+        localHostSocket = null;
+        if (tmpLHSoc != null) {
+            try {print_debug("BtToSocketBase","Close localHostSocket");
+                tmpLHSoc.close();} catch (Exception e) {
+                print_debug("BtToSocketBase","Close error : " + e.toString());
+            }
+        }
+    }
+    public void SetIdAddressAndName(String peerId,String peerName,String peerAddress) {
+        mPeerId = peerId;
+        mPeerName = peerName;
+        mPeerAddress = peerAddress;
+    }
+    public String GetPeerId() {
+        return mPeerId;
+    }
+    public String GetPeerName(){return mPeerName;}
+    public String GetPeerAddress(){return mPeerAddress;}
+
+    protected  void print_debug(String who,String message){
+        Log.i(who, message);
+    }
+}

--- a/src/android/java/io/jxcore/node/BtToSocketBase.java
+++ b/src/android/java/io/jxcore/node/BtToSocketBase.java
@@ -13,14 +13,14 @@ import java.net.Socket;
  */
 public class BtToSocketBase extends Thread implements StreamCopyingThread.CopyThreadCallback  {
 
-    BtToSocketBase that = this;
+    final BtToSocketBase that = this;
     protected final BtSocketDisconnectedCallBack mHandler;
 
-    protected BluetoothSocket mmSocket = null;
+    protected final BluetoothSocket mmSocket;
     protected Socket localHostSocket = null;
 
-    protected InputStream mmInStream = null;
-    protected OutputStream mmOutStream = null;
+    protected final InputStream mmInStream;
+    protected final OutputStream mmOutStream;
     protected InputStream LocalInputStream = null;
     protected OutputStream LocalOutputStream = null;
 
@@ -85,25 +85,19 @@ public class BtToSocketBase extends Thread implements StreamCopyingThread.CopyTh
 
         CloseSocketAndStreams();
 
-        InputStream tmpInStr = mmInStream;
-        mmInStream = null;
-        if (tmpInStr != null) {
+        if (mmInStream != null) {
             try {print_debug("BtToSocketBase","Close bt in");
-                tmpInStr.close();} catch (Exception e) {print_debug("BtToSocketBase","Close error : " + e.toString());}
+                mmInStream.close();} catch (IOException e) {print_debug("BtToSocketBase","Close error : " + e.toString());}
         }
 
-        OutputStream tmpOutStr = mmOutStream;
-        mmOutStream = null;
-        if (tmpOutStr != null) {
+        if (mmOutStream != null) {
             try {print_debug("BtToSocketBase","Close bt out");
-                tmpOutStr.close();} catch (Exception e) {print_debug("BtToSocketBase","Close error : " + e.toString());}
+                mmOutStream.close();} catch (IOException e) {print_debug("BtToSocketBase","Close error : " + e.toString());}
         }
 
-        BluetoothSocket tmpSoc = mmSocket;
-        mmSocket = null;
-        if (tmpSoc != null) {
+        if (mmSocket != null) {
             try {print_debug("BtToSocketBase","Close bt socket");
-                tmpSoc.close();} catch (Exception e) {print_debug("BtToSocketBase","Close error : " + e.toString());}
+                mmSocket.close();} catch (IOException e) {print_debug("BtToSocketBase","Close error : " + e.toString());}
         }
     }
 

--- a/src/android/java/io/jxcore/node/ConnectivityMonitor.java
+++ b/src/android/java/io/jxcore/node/ConnectivityMonitor.java
@@ -22,31 +22,34 @@ public class ConnectivityMonitor {
     BroadcastReceiver receiver = null;
     Activity activity = jxcore.activity;
 
-    public ConnectivityMonitor(){
-    }
+    public ConnectivityMonitor(){}
 
-    public void Start(){
+    public void Start() {
         Stop();
         IntentFilter filter = new IntentFilter();
         filter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
 
-        receiver = new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                SendConnectivityInfo();
-            }
-        };
+        try {
+            receiver = new BroadcastReceiver() {
+                @Override
+                public void onReceive(Context context, Intent intent) {
+                    SendConnectivityInfo();
+                }
+            };
 
-        activity.registerReceiver(receiver, filter);
-
-        //To do fix this once we know how to get events that all is ready !
-        SendConnectivityInfo();
+            activity.registerReceiver(receiver, filter);
+            //To do fix this once we know how to get events that all is ready !
+            SendConnectivityInfo();
+        } catch (Exception e) {e.printStackTrace();}
     }
 
-    public void Stop(){
-        if(receiver != null) {
-            activity.unregisterReceiver(receiver);
-            receiver = null;
+    public void Stop() {
+        BroadcastReceiver tmpRec= receiver;
+        receiver = null;
+        if (tmpRec != null) {
+            try {
+                activity.unregisterReceiver(tmpRec);
+            } catch (Exception e) {e.printStackTrace();}
         }
     }
 

--- a/src/android/java/io/jxcore/node/ConnectivityMonitor.java
+++ b/src/android/java/io/jxcore/node/ConnectivityMonitor.java
@@ -40,7 +40,7 @@ class ConnectivityMonitor {
             activity.registerReceiver(receiver, filter);
             //To do fix this once we know how to get events that all is ready !
             SendConnectivityInfo();
-        } catch (Exception e) {e.printStackTrace();}
+        } catch (IllegalArgumentException e) {e.printStackTrace();}
     }
 
     public void Stop() {
@@ -49,7 +49,7 @@ class ConnectivityMonitor {
         if (tmpRec != null) {
             try {
                 activity.unregisterReceiver(tmpRec);
-            } catch (Exception e) {e.printStackTrace();}
+            } catch (IllegalArgumentException e) {e.printStackTrace();}
         }
     }
 

--- a/src/android/java/io/jxcore/node/ConnectivityMonitor.java
+++ b/src/android/java/io/jxcore/node/ConnectivityMonitor.java
@@ -8,6 +8,12 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.jxcore.node.JXcoreExtension;
+import io.jxcore.node.jxcore;
+
 /**
  * Created by juksilve on 14.5.2015.
  */
@@ -58,14 +64,18 @@ public class ConnectivityMonitor {
         activity.runOnUiThread(new Runnable() {
             public void run() {
 
-                String reply = "";
-                if (isConnected) {
-                    reply = "{\"" + JXcoreExtension.EVENTVALUESTRING_REACHABLE + "\":\"" + isConnected + "\", " + "\"" + JXcoreExtension.EVENTVALUESTRING_WIFI + "\":\"" + isWiFi + "\"}";
-                } else {
-                    reply = "{\"" + JXcoreExtension.EVENTVALUESTRING_REACHABLE + "\":\"" + isConnected + "\"}";
+                JSONObject tmp = new JSONObject();
+                try {
+                    tmp.put(JXcoreExtension.EVENTVALUESTRING_REACHABLE, isConnected);
+                    if(isConnected) {
+                        tmp.put(JXcoreExtension.EVENTVALUESTRING_WIFI, isWiFi);
+                    }
+                } catch (JSONException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
                 }
 
-                jxcore.CallJSMethod(JXcoreExtension.EVENTSTRING_NETWORKCHANGED, reply);
+                jxcore.CallJSMethod(JXcoreExtension.EVENTSTRING_NETWORKCHANGED, tmp.toString());
             }
         });
     }

--- a/src/android/java/io/jxcore/node/ConnectivityMonitor.java
+++ b/src/android/java/io/jxcore/node/ConnectivityMonitor.java
@@ -17,10 +17,10 @@ import io.jxcore.node.jxcore;
 /**
  * Created by juksilve on 14.5.2015.
  */
-public class ConnectivityMonitor {
+class ConnectivityMonitor {
 
-    BroadcastReceiver receiver = null;
-    Activity activity = jxcore.activity;
+    private BroadcastReceiver receiver = null;
+    private final Activity activity = jxcore.activity;
 
     public ConnectivityMonitor(){}
 
@@ -53,7 +53,7 @@ public class ConnectivityMonitor {
         }
     }
 
-    public void SendConnectivityInfo() {
+    private void SendConnectivityInfo() {
 
         ConnectivityManager connectivity = (ConnectivityManager) activity.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo activeNetwork = connectivity.getActiveNetworkInfo();
@@ -67,18 +67,18 @@ public class ConnectivityMonitor {
         activity.runOnUiThread(new Runnable() {
             public void run() {
 
-                JSONObject tmp = new JSONObject();
-                try {
-                    tmp.put(JXcoreExtension.EVENTVALUESTRING_REACHABLE, isConnected);
-                    if(isConnected) {
-                        tmp.put(JXcoreExtension.EVENTVALUESTRING_WIFI, isWiFi);
-                    }
-                } catch (JSONException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+            JSONObject tmp = new JSONObject();
+            try {
+                tmp.put(JXcoreExtension.EVENTVALUESTRING_REACHABLE, isConnected);
+                if(isConnected) {
+                    tmp.put(JXcoreExtension.EVENTVALUESTRING_WIFI, isWiFi);
                 }
+            } catch (JSONException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
 
-                jxcore.CallJSMethod(JXcoreExtension.EVENTSTRING_NETWORKCHANGED, tmp.toString());
+            jxcore.CallJSMethod(JXcoreExtension.EVENTSTRING_NETWORKCHANGED, tmp.toString());
             }
         });
     }

--- a/src/android/java/io/jxcore/node/JXcoreExtension.java
+++ b/src/android/java/io/jxcore/node/JXcoreExtension.java
@@ -4,13 +4,7 @@ package io.jxcore.node;
 
 import io.jxcore.node.jxcore.JXcoreCallback;
 import java.util.ArrayList;
-import android.annotation.SuppressLint;
-import android.content.Context;
-import android.graphics.Point;
-import android.provider.Settings.SettingNotFoundException;
 import android.util.Log;
-import android.view.Display;
-import android.view.WindowManager;
 import android.widget.Toast;
 
 import org.thaliproject.p2p.btconnectorlib.BTConnector;
@@ -205,9 +199,11 @@ public class JXcoreExtension {
                   }
               });
 
-              if(stopped){
+              // todo if we get Postcard fixed on lifecycle handling we should re-enable this
+              // now we need to just trust that postcard will shutdown correctly
+           /*   if(stopped){
                   mBtConnectorHelper.Stop();
-              }
+              }*/
           }
       });
       mLifeCycleMonitor.Start();

--- a/src/android/java/io/jxcore/node/JXcoreExtension.java
+++ b/src/android/java/io/jxcore/node/JXcoreExtension.java
@@ -42,7 +42,7 @@ public class JXcoreExtension {
                   String message = params.get(0).toString();
                   boolean isLong = true;
                   if (params.size() == 2) {
-                      isLong = ((Boolean) params.get(1)).booleanValue();
+                      isLong = (Boolean) params.get(1);
                   }
 
                   int duration = Toast.LENGTH_SHORT;
@@ -66,15 +66,15 @@ public class JXcoreExtension {
           @Override
           public void Receiver(ArrayList<Object> params, String callbackId) {
 
+              String errString = "";
+              ArrayList<Object> args = new ArrayList<Object>();
+
               if(params.size() > 1) {
                   String peerName = params.get(0).toString();
-                  String port = params.get(1).toString();
-
-                  String errString = "";
-                  ArrayList<Object> args = new ArrayList<Object>();
+                  int port = (Integer)params.get(1);//.toString();
 
                   if(!mBtConnectorHelper.isRunning()) {
-                      BTConnector.WifiBtStatus retVal = mBtConnectorHelper.Start(peerName, Integer.decode(port));
+                      BTConnector.WifiBtStatus retVal = mBtConnectorHelper.Start(peerName, port);
 
                       if (retVal.isWifiEnabled && retVal.isWifiOk && retVal.isBtEnabled && retVal.isBtOk) {
                           args.add(null);
@@ -96,9 +96,13 @@ public class JXcoreExtension {
                       errString ="Already running, not re-starting.";
                       args.add(errString);
                   }
-                  Log.i("DEBUG-TEST" , METHODSTRING_STARTBROADCAST + "called, we return Err string as : " + errString);
-                  jxcore.CallJSMethod(callbackId, args.toArray());
+              }else{
+                  errString ="Not enough parameters with function call.";
+                  args.add(errString);
               }
+
+              Log.i("DEBUG-TEST" , METHODSTRING_STARTBROADCAST + "called, we return Err string as : " + errString);
+              jxcore.CallJSMethod(callbackId, args.toArray());
           }
       });
 

--- a/src/android/java/io/jxcore/node/JXcoreExtension.java
+++ b/src/android/java/io/jxcore/node/JXcoreExtension.java
@@ -11,24 +11,23 @@ import org.thaliproject.p2p.btconnectorlib.BTConnector;
 
 public class JXcoreExtension {
 
-    public static String EVENTSTRING_PEERAVAILABILITY   = "peerAvailabilityChanged";
-    public static String EVENTVALUESTRING_PEERID        = "peerIdentifier";
-    public static String EVENTVALUESTRING_PEERNAME      = "peerName";
-    public static String EVENTVALUESTRING_PEERAVAILABLE = "peerAvailable";
+    public final static String EVENTSTRING_PEERAVAILABILITY   = "peerAvailabilityChanged";
+    public final static String EVENTVALUESTRING_PEERID        = "peerIdentifier";
+    public final static String EVENTVALUESTRING_PEERNAME      = "peerName";
+    public final static String EVENTVALUESTRING_PEERAVAILABLE = "peerAvailable";
 
-    public static String EVENTSTRING_NETWORKCHANGED     = "networkChanged";
-    public static String EVENTVALUESTRING_REACHABLE     = "isReachable";
-    public static String EVENTVALUESTRING_WIFI          = "isWiFi";
+    public final static String EVENTSTRING_NETWORKCHANGED     = "networkChanged";
+    public final static String EVENTVALUESTRING_REACHABLE     = "isReachable";
+    public final static String EVENTVALUESTRING_WIFI          = "isWiFi";
 
-    public static String METHODSTRING_SHOWTOAST         = "ShowToast";
+    public final static String METHODSTRING_SHOWTOAST         = "ShowToast";
 
-    public static String METHODSTRING_STARTBROADCAST    = "StartBroadcasting";
-    public static String METHODSTRING_STOPBROADCAST     = "StopBroadcasting";
+    public final static String METHODSTRING_STARTBROADCAST    = "StartBroadcasting";
+    public final static String METHODSTRING_STOPBROADCAST     = "StopBroadcasting";
 
-    public static String METHODSTRING_CONNECTTOPEER     = "Connect";
-    public static String METHODSTRING_DISCONNECTPEER    = "Disconnect";
-    public static String METHODSTRING_KILLCONNECTION    = "KillConnection";
-
+    public final static String METHODSTRING_CONNECTTOPEER     = "Connect";
+    public final static String METHODSTRING_DISCONNECTPEER    = "Disconnect";
+    public final static String METHODSTRING_KILLCONNECTION    = "KillConnection";
 
     public static void LoadExtensions() {
 
@@ -191,7 +190,6 @@ public class JXcoreExtension {
 
           @Override
           public void onEvent(String eventString,boolean stopped) {
-              final String messageTmp = eventString;
               jxcore.activity.runOnUiThread(new Runnable(){
                   public void run() {
               //        String reply = "{\"lifecycleevent\":\"" + messageTmp + "\"}";

--- a/src/android/java/io/jxcore/node/LifeCycleMonitor.java
+++ b/src/android/java/io/jxcore/node/LifeCycleMonitor.java
@@ -9,12 +9,12 @@ import io.jxcore.node.jxcore;
 /**
  * Created by juksilve on 13.5.2015.
  */
-public class LifeCycleMonitor implements Application.ActivityLifecycleCallbacks {
+class LifeCycleMonitor implements Application.ActivityLifecycleCallbacks {
 
-    Application MyApp = null;
+    private Application MyApp = null;
 
     public interface onLCEventCallback{
-        public void onEvent(String eventString, boolean stopped);
+        void onEvent(String eventString, boolean stopped);
     }
 
     public final String ACTIVITY_CREATED   = "onActivityCreated";
@@ -26,8 +26,8 @@ public class LifeCycleMonitor implements Application.ActivityLifecycleCallbacks 
     public final String ACTIVITY_DESTROYED = "onActivityDestroyed";
 
     //BtConnectorHelper.jxCallBack jxcore = null; // remove the line
-    Activity activity = jxcore.activity;
-    onLCEventCallback callback = null;
+    private final Activity activity = jxcore.activity;
+    private onLCEventCallback callback = null;
     public LifeCycleMonitor(onLCEventCallback Callback) {
         callback = Callback;
     }

--- a/src/android/java/io/jxcore/node/LifeCycleMonitor.java
+++ b/src/android/java/io/jxcore/node/LifeCycleMonitor.java
@@ -33,16 +33,23 @@ public class LifeCycleMonitor implements Application.ActivityLifecycleCallbacks 
     }
 
     public void Start() {
-        this.MyApp = activity.getApplication();
-        if (this.MyApp != null) {
-            this.MyApp.registerActivityLifecycleCallbacks(this);
+        Application tmpApp = activity.getApplication();
+        if (tmpApp != null) {
+            try {
+                tmpApp.registerActivityLifecycleCallbacks(this);
+            }catch(Exception e){e.printStackTrace();}
         }
+
+        this.MyApp = tmpApp;
     }
 
     public void Stop() {
-        if (this.MyApp != null) {
-            this.MyApp.unregisterActivityLifecycleCallbacks(this);
-            this.MyApp = null;
+        Application tmpApp = this.MyApp;
+        this.MyApp = null;
+        if (tmpApp != null) {
+            try {
+                tmpApp.unregisterActivityLifecycleCallbacks(this);
+            } catch (Exception e) {e.printStackTrace();}
         }
     }
 

--- a/src/android/java/io/jxcore/node/LifeCycleMonitor.java
+++ b/src/android/java/io/jxcore/node/LifeCycleMonitor.java
@@ -37,7 +37,7 @@ class LifeCycleMonitor implements Application.ActivityLifecycleCallbacks {
         if (tmpApp != null) {
             try {
                 tmpApp.registerActivityLifecycleCallbacks(this);
-            }catch(Exception e){e.printStackTrace();}
+            }catch(IllegalArgumentException e){e.printStackTrace();}
         }
 
         this.MyApp = tmpApp;
@@ -49,7 +49,7 @@ class LifeCycleMonitor implements Application.ActivityLifecycleCallbacks {
         if (tmpApp != null) {
             try {
                 tmpApp.unregisterActivityLifecycleCallbacks(this);
-            } catch (Exception e) {e.printStackTrace();}
+            } catch (IllegalArgumentException e) {e.printStackTrace();}
         }
     }
 

--- a/src/android/java/io/jxcore/node/LifeCycleMonitor.java
+++ b/src/android/java/io/jxcore/node/LifeCycleMonitor.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
 
+import io.jxcore.node.jxcore;
+
 /**
  * Created by juksilve on 13.5.2015.
  */

--- a/src/android/java/io/jxcore/node/StreamCopyingThread.java
+++ b/src/android/java/io/jxcore/node/StreamCopyingThread.java
@@ -15,8 +15,6 @@ class StreamCopyingThread extends Thread {
     }
 
     private final CopyThreadCallback callback;
-
-    private String TAG = "StreamCopyingThread";
     private boolean mStopped = false;
 
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
@@ -30,10 +28,6 @@ class StreamCopyingThread extends Thread {
         mOutputStream = mmOutStreamt;
     }
 
-    public void setDebugTag(String debugTag) {
-        TAG = debugTag;
-    }
-
     public void run() {
         byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
 
@@ -42,7 +36,7 @@ class StreamCopyingThread extends Thread {
                 int n = 0;
                 while (-1 != (n = mInputStream.read(buffer)) && !mStopped) {
                     //   String dbgMessage = new String(buffer,0,n);
-                    //   print_debug(" Copying " + n + " bytes, data: " + dbgMessage);
+                    //   Log.i (" Copying " + n + " bytes, data: " + dbgMessage);
                     mOutputStream.write(buffer, 0, n);
                 }
 
@@ -56,14 +50,9 @@ class StreamCopyingThread extends Thread {
                 callback.StreamCopyError(this, "disconnected: " + e.toString());
             }
         }
-        // print_debug("run ended");
     }
 
     public void Stop(){
         mStopped = true;
     }
-
-  /*  public void print_debug(String message){
-        Log.i(TAG, message);
-    }*/
 }

--- a/src/android/java/io/jxcore/node/StreamCopyingThread.java
+++ b/src/android/java/io/jxcore/node/StreamCopyingThread.java
@@ -8,18 +8,18 @@ import java.io.OutputStream;
 /**
  * Created by juksilve on 5.6.2015.
  */
-public class StreamCopyingThread extends Thread {
+class StreamCopyingThread extends Thread {
 
 
     interface CopyThreadCallback
     {
-        public void StreamCopyError(StreamCopyingThread who, String error);
+        void StreamCopyError(StreamCopyingThread who, String error);
     }
 
-    CopyThreadCallback callback = null;
+    private CopyThreadCallback callback = null;
 
-    String TAG = "StreamCopyingThread";
-    boolean mStopped = false;
+    private String TAG = "StreamCopyingThread";
+    private boolean mStopped = false;
 
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
 
@@ -32,8 +32,8 @@ public class StreamCopyingThread extends Thread {
         mOutputStream = mmOutStreamt;
     }
 
-    public void setDebugTag(String debugtag) {
-        TAG = debugtag;
+    public void setDebugTag(String debugTag) {
+        TAG = debugTag;
     }
 
     public void run() {
@@ -59,7 +59,7 @@ public class StreamCopyingThread extends Thread {
                 callback.StreamCopyError(this, "disconnected: " + e.toString());
             }
 
-            print_debug("run ended");
+           // print_debug("run ended");
         }
     }
 
@@ -67,7 +67,7 @@ public class StreamCopyingThread extends Thread {
         mStopped = true;
     }
 
-    public void print_debug(String message){
-    //    Log.i(TAG, message);
-    }
+  /*  public void print_debug(String message){
+        Log.i(TAG, message);
+    }*/
 }

--- a/src/android/java/io/jxcore/node/StreamCopyingThread.java
+++ b/src/android/java/io/jxcore/node/StreamCopyingThread.java
@@ -39,32 +39,28 @@ public class StreamCopyingThread extends Thread {
     public void run() {
         byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
 
-        while (!mStopped){
+        while (!mStopped) {
             try {
-                if (!mStopped) {
-                    if (mInputStream != null && mOutputStream != null) {
-                        int n = 0;
-                        while (-1 != (n = mInputStream.read(buffer)) && !mStopped) {
-                         //   String dbgMessage = new String(buffer,0,n);
-                         //   print_debug(" Copying " + n + " bytes, data: " + dbgMessage);
-                            mOutputStream.write(buffer, 0, n);
-                        }
+                if (mInputStream != null && mOutputStream != null) {
+                    int n = 0;
+                    while (-1 != (n = mInputStream.read(buffer)) && !mStopped) {
+                        //   String dbgMessage = new String(buffer,0,n);
+                        //   print_debug(" Copying " + n + " bytes, data: " + dbgMessage);
+                        mOutputStream.write(buffer, 0, n);
+                    }
 
-                        if(n == -1){
-                            mStopped = true;
-                            callback.StreamCopyError(this, "input stream got -1 on read");
-                        }
+                    if (n == -1) {
+                        mStopped = true;
+                        callback.StreamCopyError(this, "input stream got -1 on read");
                     }
                 }
             } catch (IOException e) {
-                if (!mStopped) {
-                    mStopped = true;
-                    callback.StreamCopyError(this, "disconnected: " + e.toString());
-                }
+                mStopped = true;
+                callback.StreamCopyError(this, "disconnected: " + e.toString());
             }
-        }
 
-        print_debug("run ended");
+            print_debug("run ended");
+        }
     }
 
     public void Stop(){

--- a/src/android/java/io/jxcore/node/StreamCopyingThread.java
+++ b/src/android/java/io/jxcore/node/StreamCopyingThread.java
@@ -10,21 +10,19 @@ import java.io.OutputStream;
  */
 class StreamCopyingThread extends Thread {
 
-
-    interface CopyThreadCallback
-    {
+    interface CopyThreadCallback{
         void StreamCopyError(StreamCopyingThread who, String error);
     }
 
-    private CopyThreadCallback callback = null;
+    private final CopyThreadCallback callback;
 
     private String TAG = "StreamCopyingThread";
     private boolean mStopped = false;
 
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
 
-    private InputStream mInputStream = null;
-    private OutputStream mOutputStream = null;
+    private final InputStream mInputStream;
+    private final  OutputStream mOutputStream;
 
     public StreamCopyingThread(CopyThreadCallback Callback,InputStream mmInStream,OutputStream mmOutStreamt){
         callback = Callback;
@@ -41,26 +39,24 @@ class StreamCopyingThread extends Thread {
 
         while (!mStopped) {
             try {
-                if (mInputStream != null && mOutputStream != null) {
-                    int n = 0;
-                    while (-1 != (n = mInputStream.read(buffer)) && !mStopped) {
-                        //   String dbgMessage = new String(buffer,0,n);
-                        //   print_debug(" Copying " + n + " bytes, data: " + dbgMessage);
-                        mOutputStream.write(buffer, 0, n);
-                    }
-
-                    if (n == -1) {
-                        mStopped = true;
-                        callback.StreamCopyError(this, "input stream got -1 on read");
-                    }
+                int n = 0;
+                while (-1 != (n = mInputStream.read(buffer)) && !mStopped) {
+                    //   String dbgMessage = new String(buffer,0,n);
+                    //   print_debug(" Copying " + n + " bytes, data: " + dbgMessage);
+                    mOutputStream.write(buffer, 0, n);
                 }
+
+                if (n == -1) {
+                    mStopped = true;
+                    callback.StreamCopyError(this, "input stream got -1 on read");
+                }
+
             } catch (IOException e) {
                 mStopped = true;
                 callback.StreamCopyError(this, "disconnected: " + e.toString());
             }
-
-           // print_debug("run ended");
         }
+        // print_debug("run ended");
     }
 
     public void Stop(){

--- a/src/android/java/io/jxcore/node/StreamCopyingThread.java
+++ b/src/android/java/io/jxcore/node/StreamCopyingThread.java
@@ -1,6 +1,5 @@
 package io.jxcore.node;
 
-import android.util.Log;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/test/www/jxcore/tcpmultiplexspec.js
+++ b/test/www/jxcore/tcpmultiplexspec.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var tcpmultiplex = require('./thali/tcpmultiplex');
+var test = require('tape');
+var net = require('net');
+var randomstring = require('randomstring');
+
+test('serverMuxBridge can mux data', function (t) {
+  var len = 200;
+  var testMessage = randomstring.generate(len);
+
+  var server = net.createServer(function (socket) {
+    socket.pipe(socket);
+  });
+
+  server.listen(5001, function () {
+    var muxServerBridge = tcpmultiplex.muxServerBridge(5001);
+    muxServerBridge.listen(5000, function () {
+
+      var clientSocket = net.createConnection( { port: 5001 }, function () {
+        clientSocket.write(Buffer(testMessage));
+      });
+
+      clientSocket.on('data', function (data) {
+        t.equal(testMessage, data.toString(), 'Should send ' + testMessage.length + ' characters');
+        t.end();
+
+        muxServerBridge.close();
+        server.close();
+      });
+    });
+  });
+});
+
+test('clientMuxBridge can mux data', function (t) {
+  var len = 200;
+  var testMessage = randomstring.generate(len);
+
+  var server = net.createServer(function (socket) {
+    socket.pipe(socket);
+  });
+
+  server.listen(5001, function () {
+    var muxClientBridge = tcpmultiplex.muxClientBridge(5001);
+    muxClientBridge.listen(5000, function () {
+
+      var clientSocket = net.createConnection( { port: 5001 }, function () {
+        clientSocket.write(Buffer(testMessage));
+      });
+
+      clientSocket.on('data', function (data) {
+        t.equal(testMessage, data.toString(), 'Should send ' + testMessage.length + ' characters');
+        t.end();
+
+        muxClientBridge.close();
+        server.close();
+      });
+    });
+  });
+});

--- a/thali/tcpmultiplex.js
+++ b/thali/tcpmultiplex.js
@@ -1,0 +1,114 @@
+var net = require('net');
+var multiplex = require('multiplex');
+
+function muxServerBridge(tcpEndpointServerPort) {
+  // Keep track of all the client sockets we've seen
+  var clientSockets = {};
+
+  var server = net.createServer(function(incomingClientSocket) {
+
+    incomingClientSocket.on('close', function () {
+      // Remove the closed socket from out records, destroying (by
+      // unref-fing) the multiplexer (we hope)
+      console.log('server bridge: socket closed');
+      delete clientSockets[incomingClientSocket];
+    });
+
+    incomingClientSocket.on('timeout', function () {
+      console.log('incoming client socket timeout');
+    });
+
+    incomingClientSocket.on('error', function (err) {
+      console.log('incoming client socket error %s', err);
+    });
+
+    console.log('server bridge: new client socket');
+
+    // We'll need a new multiplex object for each incoming socket
+    var serverPlex = multiplex({}, function(stream, id) {
+      var clientSocket = net.createConnection({port: tcpEndpointServerPort});
+      stream.pipe(clientSocket).pipe(stream);
+    });
+
+    // Record the mapping between incoming socket and multiplex
+    clientSockets[incomingClientSocket] = serverPlex;
+    incomingClientSocket.pipe(serverPlex).pipe(incomingClientSocket);
+  });
+
+  server.on('error', function (err) {
+    console.log('mux server bridge error %s', err);
+  });
+
+  server.on('close', function () {
+    // Close all the client sockets, this'll force the server object
+    // to *really* close
+    console.log('server bridge: server closing (%d)', Object.keys(clientSockets).length);
+    // Shutdown all the connected sockets
+    Object.keys(clientSockets).forEach(function (key) {
+      var sock = clientSockets[key];
+      sock.end();
+      sock.destroy();
+    })
+    clientSockets = {};
+  });
+
+  return server;
+}
+
+function muxClientBridge(localP2PTcpServerPort) {
+  var clientPlex = multiplex();
+  var clientSocket = net.createConnection({port: localP2PTcpServerPort});
+
+  // Keep track of all the client sockets we've seen
+  var clientStreams = {};
+
+  var server = net.createServer(function(incomingClientSocket) {
+    var clientStream = clientPlex.createStream();
+
+    incomingClientSocket.on('close', function () {
+      // Remove the closed socket from out records, destroying (by
+      // unref-fing) the multiplexer (we hope)
+      console.log('client bridge: socket closed');
+      delete clientStreams[incomingClientSocket];
+    });
+
+    incomingClientSocket.on('timeout', function () {
+      console.log('incoming client socket timeout');
+    });
+
+    incomingClientSocket.on('error', function (err) {
+      console.log('incoming client socket error %s', err);
+    });
+
+    console.log('client bridge: new client socket');
+
+    clientStreams[incomingClientSocket] = clientStream;
+    incomingClientSocket.pipe(clientStream).pipe(incomingClientSocket);
+  });
+
+  server.on('error', function (err) {
+    console.log('mux client bridge error %s', err);
+  });
+
+  server.on('close', function () {
+    // Close all the client sockets, this'll force the server object
+    // to *really* close
+    console.log('client bridge: server closing (%d)', Object.keys(clientSockets).length);
+    // Shutdown all the connected sockets
+    Object.keys(clientStreams).forEach(function (key) {
+      var streams = clientStreams[key];
+      streams.end();
+      streams.destroy();
+    })
+    clientStreams = {};
+  });
+
+  clientPlex.pipe(clientSocket).pipe(clientPlex);
+
+  return server;
+}
+
+module.exports = {
+  muxServerBridge: muxServerBridge,
+  muxClientBridge: muxClientBridge
+};

--- a/thali/tcpmultiplex.js
+++ b/thali/tcpmultiplex.js
@@ -3,7 +3,7 @@ var multiplex = require('multiplex');
 
 function muxServerBridge(tcpEndpointServerPort) {
   // Keep track of all the client sockets we've seen
-  var clientSockets = {};
+  var clientSockets = [];
 
   var server = net.createServer(function(incomingClientSocket) {
 
@@ -11,7 +11,7 @@ function muxServerBridge(tcpEndpointServerPort) {
       // Remove the closed socket from out records, destroying (by
       // unref-fing) the multiplexer (we hope)
       console.log('server bridge: socket closed');
-      delete clientSockets[incomingClientSocket];
+      clientSockets.splice(clientSockets.indexOf(incomingClientSocket), 1);
     });
 
     incomingClientSocket.on('timeout', function () {
@@ -31,7 +31,7 @@ function muxServerBridge(tcpEndpointServerPort) {
     });
 
     // Record the mapping between incoming socket and multiplex
-    clientSockets[incomingClientSocket] = serverPlex;
+    clientSockets.push(serverPlex);
     incomingClientSocket.pipe(serverPlex).pipe(incomingClientSocket);
   });
 
@@ -42,25 +42,30 @@ function muxServerBridge(tcpEndpointServerPort) {
   server.on('close', function () {
     // Close all the client sockets, this'll force the server object
     // to *really* close
-    console.log('server bridge: server closing (%d)', Object.keys(clientSockets).length);
+    console.log('server bridge: server closing (%d)', clientSockets.length);
     // Shutdown all the connected sockets
-    Object.keys(clientSockets).forEach(function (key) {
-      var sock = clientSockets[key];
+    clientSockets.forEach(function (sock) {
       sock.end();
       sock.destroy();
-    })
-    clientSockets = {};
+    });
+    clientSockets.length = 0;
   });
 
   return server;
 }
 
-function muxClientBridge(localP2PTcpServerPort) {
+function muxClientBridge(localP2PTcpServerPort, cb) {
   var clientPlex = multiplex();
-  var clientSocket = net.createConnection({port: localP2PTcpServerPort});
+  var clientSocket = net.createConnection({port: localP2PTcpServerPort}, function () {
+    cb();
+  });
+
+  clientSocket.on('error', function (err) {
+    cb(err);
+  });
 
   // Keep track of all the client sockets we've seen
-  var clientStreams = {};
+  var clientSockets = [];
 
   var server = net.createServer(function(incomingClientSocket) {
     var clientStream = clientPlex.createStream();
@@ -69,7 +74,7 @@ function muxClientBridge(localP2PTcpServerPort) {
       // Remove the closed socket from out records, destroying (by
       // unref-fing) the multiplexer (we hope)
       console.log('client bridge: socket closed');
-      delete clientStreams[incomingClientSocket];
+      clientSockets.splice(clientSockets.indexOf(incomingClientSocket), 1);
     });
 
     incomingClientSocket.on('timeout', function () {
@@ -82,7 +87,7 @@ function muxClientBridge(localP2PTcpServerPort) {
 
     console.log('client bridge: new client socket');
 
-    clientStreams[incomingClientSocket] = clientStream;
+    clientSockets.push(incomingClientSocket);
     incomingClientSocket.pipe(clientStream).pipe(incomingClientSocket);
   });
 
@@ -93,14 +98,14 @@ function muxClientBridge(localP2PTcpServerPort) {
   server.on('close', function () {
     // Close all the client sockets, this'll force the server object
     // to *really* close
-    console.log('client bridge: server closing (%d)', Object.keys(clientSockets).length);
+    console.log('client bridge: server closing (%d)', clientSockets.length);
     // Shutdown all the connected sockets
-    Object.keys(clientStreams).forEach(function (key) {
-      var streams = clientStreams[key];
-      streams.end();
-      streams.destroy();
-    })
-    clientStreams = {};
+    clientSockets.forEach(function (sock) {
+      sock.end();
+      sock.destroy();
+    });
+    
+    clientSockets.length = 0;
   });
 
   clientPlex.pipe(clientSocket).pipe(clientPlex);

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -178,7 +178,7 @@ function syncPeer(peer) {
     if (err) {
       console.log('Connect error with error: %s', err);
       this.emit(ThaliReplicationManager.events.CONNECT_ERROR, err);
-      syncRetry.call(this, peer);
+      setImmediate(syncRetry.bind(this, peer));
     } else {
       var client = muxClientBridge.call(this, port, peer);
       this._clients[peer.peerIdentifier] = client;
@@ -258,7 +258,7 @@ function muxClientBridge(localP2PTcpServerPort, peer) {
     } catch(e) {
       this.emit(ThaliReplicationManager.events.SYNC_ERROR, e);
     }
-    syncRetry.call(this, peer);
+    setImmediate(syncRetry.bind(this, peer));
   }.bind(this));
 
   clientPlex.pipe(clientSocket).pipe(clientPlex);

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -131,11 +131,11 @@ ThaliReplicationManager.prototype._syncPeers = function (peers) {
 
   peers.forEach(function (peer) {
 
-    var p = this._replications[peer.peerIdentifier];
+    var existingReplication = this._replications[peer.peerIdentifier];
 
-    !p && peer.peerAvailable && this._syncPeer(peer.peerIdentifier);
+    !existingReplication && peer.peerAvailable && this._syncPeer(peer.peerIdentifier);
 
-    if (p && !peer.peerAvailable) {
+    if (existingReplication && !peer.peerAvailable) {
       var client = this._clients[peer.peerIdentifier];
       if (client) {
         this._clients[peer.peerIdentifier].close(function (err) {
@@ -147,8 +147,8 @@ ThaliReplicationManager.prototype._syncPeers = function (peers) {
         delete this._clients[peer.peerIdentifier];
       }
 
-      p.from.cancel();
-      p.to.cancel();
+      existingReplication.from.cancel();
+      existingReplication.to.cancel();
       delete this._replications[peer.peerIdentifier];
 
       this._emitter.disconnect(peer.peerIdentifier, function (err) {
@@ -211,10 +211,10 @@ ThaliReplicationManager.prototype._syncRetry = function (peerIdentifier) {
 
     delete this._clients[peerIdentifier];
   }
-  var p = this._replications[peerIdentifier];
-  if (p) {
-    p.from.cancel();
-    p.to.cancel();
+  var existingReplication = this._replications[peerIdentifier];
+  if (existingReplication) {
+    existingReplication.from.cancel();
+    existingReplication.to.cancel();
     delete this._replications[peerIdentifier];
   }
 

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -111,11 +111,11 @@ ThaliReplicationManager.prototype.stop = function () {
  */
 ThaliReplicationManager.prototype._networkChanged = function (status) {
   if (!status.isAvailable && this._isStarted) {
-    this.stop();
+    return this.stop();
   }
 
   if (status.isAvailable && !this._isStarted) {
-    this.start(this._deviceName, this._port, this._dbName);
+    return this.start(this._deviceName, this._port, this._dbName);
   }
 };
 

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -209,7 +209,6 @@ function muxServerBridge(tcpEndpointServerPort) {
 
     stream.on('error', function (err) {
       console.log('Multiplex stream error %s', err);
-      clientSocket.destroy();
     });
 
     clientSocket.on('error', function (err) {
@@ -222,7 +221,6 @@ function muxServerBridge(tcpEndpointServerPort) {
 
     incomingClientSocket.on('error', function (err) {
       console.log('incoming client socket error %s', err);
-      incomingClientSocket.destroy();
       serverPlex.destroy();
       server.close();
     });
@@ -242,6 +240,8 @@ function muxServerBridge(tcpEndpointServerPort) {
 
     incomingClientSocket.pipe(serverPlex).pipe(incomingClientSocket);
   });
+
+  server.setMaxListeners(100);
 
   return server;
 }

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -207,7 +207,8 @@ function muxServerBridge(tcpEndpointServerPort) {
     var clientSocket = net.createConnection({port: tcpEndpointServerPort});
     stream.pipe(clientSocket).pipe(stream);
 
-    clientSocket.on('end', function () {
+    stream.on('error', function (err) {
+      console.log('Multiplex stream error %s', err);
       clientSocket.destroy();
     });
 
@@ -218,19 +219,18 @@ function muxServerBridge(tcpEndpointServerPort) {
   });
 
   var server = net.createServer(function(incomingClientSocket) {
-    incomingClientSocket.on('end', function () {
-      console.log('incoming client socket end');
-    });
 
     incomingClientSocket.on('error', function (err) {
       console.log('incoming client socket error %s', err);
       incomingClientSocket.destroy();
+      serverPlex.destroy();
       server.close();
     });
 
     server.on('error', function (err) {
       console.log('mux server bridge error %s', err);
       incomingClientSocket.destroy();
+      serverPlex.destroy();
       server.close();
     });
 

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -206,7 +206,7 @@ function restartMuxServerBridge() {
   this.stop();
 
   this.on('stopped', function () {
-    this.start(this._deviceName, this._port = port, this._dbName);
+    this.start(this._deviceName, this._port, this._dbName);
   }.bind(this));
 }
 

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -186,7 +186,7 @@ ThaliReplicationManager.prototype._syncPeer = function (peerIdentifier) {
         this._replications[peer.peerIdentifier] = {
           from: this._db.replicate.from(remoteDB, options),
           to: this._db.replicate.to(remoteDB, options)
-        }
+        };
       }.bind(this));
     }
   }.bind(this));

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -203,8 +203,11 @@ function syncPeer(peer) {
 /* Mux Layer */
 
 function restartMuxServerBridge() {
-  this._serverBridge = muxServerBridge.call(this, port);
-  this._serverBridge.listen(this._serverBridgePort);
+  this.stop();
+
+  this.on('stopped', function () {
+    this.start(this._deviceName, this._port = port, this._dbName);
+  }.bind(this));
 }
 
 function muxServerBridge(tcpEndpointServerPort) {

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -291,7 +291,7 @@ function muxServerBridge(tcpEndpointServerPort) {
     }.bind(this));
 
     incomingClientSocket.pipe(serverPlex).pipe(incomingClientSocket);
-  });
+  }.bind(this));
 
   server.setMaxListeners(100);
 

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -128,6 +128,7 @@ function syncPeers(peers) {
       var client = this._clients[peer.peerIdentifier];
       if (client) {
         this._clients[peer.peerIdentifier].close(function (err) {
+          console.log('Client close error with error: %s', err);
           err && this.emit(ThaliReplicationManager.events.DISCONNECT_ERROR, err);
         });
         delete this._clients[peer.peerIdentifier];
@@ -138,6 +139,7 @@ function syncPeers(peers) {
       delete this._replications[peer.peerIdentifier];
 
       this._emitter.disconnect(peer.peerIdentifier, function (err) {
+        console.log('Disconnect error with error: %s', err);
         err && this.emit(ThaliReplicationManager.events.DISCONNECT_ERROR, err);
       }.bind(this));
     }
@@ -166,8 +168,10 @@ function syncRetry(peer) {
   }
 
   this._emitter.disconnect(peer.peerIdentifier, function (err) {
-    console.log('Disconnect error with error: %s', err);
-    this.emit(ThaliReplicationManager.events.DISCONNECT_ERROR, err);
+    if (err) {
+      console.log('Disconnect error with error: %s', err);
+      this.emit(ThaliReplicationManager.events.DISCONNECT_ERROR, err);
+    }
     this._isInRetry = false;
     syncPeer.call(this, peer);
   }.bind(this));
@@ -208,7 +212,7 @@ function muxServerBridge(tcpEndpointServerPort) {
     });
 
     clientSocket.on('error', function (err) {
-      console.log('incoming client sockiet error %s', err);
+      console.log('incoming client socket error %s', err);
       clientSocket.destroy();
     });
   });
@@ -219,7 +223,7 @@ function muxServerBridge(tcpEndpointServerPort) {
     });
 
     incomingClientSocket.on('error', function (err) {
-      console.log('incoming client sockiet error %s', err);
+      console.log('incoming client socket error %s', err);
       incomingClientSocket.destroy();
       server.close();
     });

--- a/thali/thalireplicationmanager.js
+++ b/thali/thalireplicationmanager.js
@@ -185,7 +185,7 @@ ThaliReplicationManager.prototype._syncPeer = function (peerIdentifier) {
         var options = { live: true, retry: true };
         this._replications[peer.peerIdentifier] = {
           from: this._db.replicate.from(remoteDB, options),
-          to: this._db.replicate.from(remoteDB, options)
+          to: this._db.replicate.to(remoteDB, options)
         }
       }.bind(this));
     }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36887935%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36888127%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36888210%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36888421%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36889852%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36893413%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36893551%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36893563%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36893593%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36991433%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36991828%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36991922%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36991973%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36993367%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37000055%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37000208%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37000558%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37000591%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37127600%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37127746%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37338586%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37338654%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37338687%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37338749%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37353843%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37354140%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37354248%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37354529%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37355139%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37355581%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37355798%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37356404%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37356582%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37357316%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37357377%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37357503%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37357657%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37358143%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37358226%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37358447%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37358570%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37358650%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37359026%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37359460%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37359584%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37359656%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37359820%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37360002%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37360169%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37364290%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37364572%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37364857%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37365290%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37365990%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37438236%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37438768%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37440232%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37441413%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37442588%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37442700%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37443396%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37444020%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37444651%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37444805%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37446744%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37446927%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37447066%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37447168%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37447443%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37447644%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37447766%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37448144%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37460113%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37461527%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37461708%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37461881%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37462133%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37474148%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37478904%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37478913%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37682726%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37682741%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37682809%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37682821%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37682945%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37683080%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37683097%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37683145%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685313%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685356%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685376%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685624%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685656%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685673%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685687%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685699%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685705%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685744%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685822%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685862%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685887%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685922%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37686263%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37686289%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37686308%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37723535%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37723707%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37723925%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37724094%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37724293%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37724640%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37780597%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37781092%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37782503%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37782540%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37782773%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37783008%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37783426%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37783443%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37783477%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37783666%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37784077%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37784114%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37784165%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37784260%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37784364%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37786697%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37786743%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37786778%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37786858%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37789444%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37789543%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37789596%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37789709%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37789885%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37790519%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37790569%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37790698%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37793829%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37793940%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37794573%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37794642%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37795455%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37795976%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37796358%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37797058%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37797327%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37797557%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37797690%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37811334%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37811724%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37811995%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37812889%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37813112%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37813839%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37836305%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37836443%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37836736%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37836964%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37837294%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37837318%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37837456%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37837632%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37840540%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37840594%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37840613%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37840778%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37841595%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37841740%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37841870%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37897270%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37899296%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37901398%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37901454%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37901572%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37902524%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37903569%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37903642%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37903913%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37904292%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37905501%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37905856%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37905889%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37973492%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23issuecomment-135132763%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r38019635%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r38020334%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r38020425%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r38020452%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r38020532%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r38020590%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r38021369%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r38021417%22%2C%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23issuecomment-135140310%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20179%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37359584%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20I%27m%20guessing%20line%20225%20below%20isn%27t%20correct%20since%20it%20presumes%20we%20can%20only%20connect%20to%20one%20peer%20at%20a%20time%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T22%3A04%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5Cn%5Cr%5CnWill%20be%20fixed%20I%20assume%20in%200.8.%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A11%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL194-226%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/BtToRequestSocket.java%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37795455%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22mmSocket%20and%20readyCallback%20should%20both%20be%20final.%5Cr%5Cn%5Cr%5CnAlso%20mStopped%20is%20set%20in%20lots%20of%20places%20but%20is%20never%20actually%20checked.%20What%20purpose%20does%20it%20serve%3F%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A47%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-25T17%3A58%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL1-7%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20131%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37357657%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20understand%20the%20intended%20semantics%20of%20%27ret%27.%20It%20seems%20to%20mean%20%5C%22I%20found%20and%20closed%20at%20least%20one%20server%20socket%5C%22.%20But%20why%20is%20that%20useful%3F%20I%20would%20have%20thought%20that%20you%20would%20only%20want%20to%20return%20true%20if%20you%20successfully%20closed%20all%20the%20sockets%3F%20And%20if%20there%20were%20no%20sockets%20then%20shouldn%27t%20you%20still%20return%20true%20since%20you%20did%20close%20all%20sockets%2C%20there%20just%20weren%27t%20any%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A44%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5Cn%5Cr%5CnI%27m%20going%20to%20assume%20this%20will%20get%20fixed%20in%200.8%20since%20the%20current%20functionality%20won%27t%20work%20there.%20The%20return%20value%20is%20only%20used%20for%20kill%20connection%20and%20in%200.8%20kill%20connection%20needs%20to%20be%20peer%20specific.%20So%20you%20will%20have%20to%20change%20this%20logic%20there.%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A10%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL116-139%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20130%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37357503%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Here%20you%20will%20want%20to%20use%20remove%28%29%20with%20the%20non-null%20tmp%20so%20you%20make%20sure%20you%20remove%20the%20right%20object.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A43%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A56%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL116-139%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/ConnectivityMonitor.java%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37811995%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20can%27t%20find%20any%20references%20anywhere%20in%20the%20code%20that%20call%20this%20class.%20Unless%20we%20are%20calling%20this%20by%20reflection%20it%20is%20not%20being%20used.%20In%20that%20case%20can%20we%20remove%20it%20and%20its%20reference%20in%20plugin.xml%3F%22%2C%20%22created_at%22%3A%20%222015-08-24T22%3A20%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20implementation%20was%20requested%20a%20while%20back%2C%20and%20thus%20is%20implemented.%20Supposing%20that%20its%20not%20really%20used.%20Also%20the%20life%20cycle%20monitoring%20code%20is%20supposedly%20currently%20not%20used%20at%20all.%20If%20indeed%20we%20decide%20that%20these%20are%20not%20needed%2C%20we%20could%20then%20remove%20them%20from%20the%20plugin.%22%2C%20%22created_at%22%3A%20%222015-08-25T07%3A48%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-25T19%3A04%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/ConnectivityMonitor.java%3AL8-60%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20147%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37358447%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20Can%20you%20please%20use%20a%20more%20descriptive%20name%20like%20localMBtToRequestSocket%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A52%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A59%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL194-226%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20113%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37356582%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20As%20mentioned%20above%20this%20isn%27t%20safe.%20If%20there%20are%20any%20more%20examples%20of%20this%20I%20won%27t%20call%20them%20out.%20I%27m%20going%20to%20assume%20that%20you%20will%20search%20for%20them.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A34%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A55%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL116-139%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20138%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37358143%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20Sorry%20to%20stick%20this%20comment%20here%20but%20I%20can%27t%20add%20comments%20to%20GetBluetoothAddress%2C%20GetDeviceName%20or%20SetDeviceName.%20In%20both%20cases%20shouldn%27t%20the%20return%20value%20be%20null%20if%20we%20can%27t%20get%20the%20default%20adapter%3F%20Also%20rather%20than%20using%3A%5Cr%5Cn%5Cr%5Cn%60%60%60java%5Cr%5Cnif%20%28bluetooth%20%21%3D%20null%29%20%7B%5Cr%5Cn%20%20%20ret%20%3D%20bluetooth.getName%28%29%3B%5Cr%5Cn%7D%5Cr%5Cn%5Cr%5Cnreturn%20ret%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnWouldn%27t%20it%20be%20cleaner%20to%20just%20use%3A%5Cr%5Cn%60%60%60java%5Cr%5Cnreturn%20bluetooth%20%3D%3D%20null%20%3F%20null%20%3A%20bluetooth.getName%28%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A49%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40DrJukka%20Also%20sorry%20to%20stick%20this%20comment%20here%20but%20I%27m%20limited%20by%20how%20GitHub%20reviews%20work.%20In%20any%20case%2C%20why%20is%20GetKeyValue%20and%20SetKeyValue%20still%20around%3F%20I%20thought%20we%20were%20going%20to%20get%20rid%20of%20these%3F%20Sorry%20if%20I%27ve%20lost%20my%20mind%20on%20this%20one%20but%20I%20thought%20this%20was%20functionality%20we%20removed%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A50%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A58%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL116-139%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/BtToServerSocket.java%20133%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37811724%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22StreamCopyError%20in%20this%20file%20is%20literally%20line%20for%20line%20identical%20can%20you%20please%20factor%20it%20out%20into%20some%20common%20class%3F%20We%20don%27t%20want%20to%20repeat%20code.%20It%20just%20invites%20bugs.%20In%20fact%20large%20parts%20of%20BtToRequestSocket%20and%20BtToServerSocket%20are%20identical%20include%20StreamCopyError%2C%20big%20chunks%20of%20run%28%29%2C%20GetLocalHostPort%2C%20GetLocalHostAddressAsString%2C%20Stop%28%29%2C%20SetIdAddressAndName%2C%20GetPeerId%2C%20GetPeerName%2C%20GetPeerAddress%20and%20print_Debug.%20Can%20you%20please%20factor%20all%20these%20methods%20out%20into%20a%20common%20base%20class%20and%20inherit%20from%20there%3F%22%2C%20%22created_at%22%3A%20%222015-08-24T22%3A17%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done.%22%2C%20%22created_at%22%3A%20%222015-08-25T07%3A46%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-26T18%3A52%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-26T18%3A52%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToServerSocket.java%3AL59-109%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37444805%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22And%20yes%20%28I%20just%20saw%20this%20in%20IntelliJ%20as%20well%29%2C%20this%20can%20be%20simplified%20to%20%60return%20mBTConnector%20%21%3D%20null%60%22%2C%20%22created_at%22%3A%20%222015-08-19T17%3A48%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222015-08-24T07%3A03%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A37%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL52-70%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/JXcoreExtension.java%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37813112%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20METHODSTRING_STARTBROADCAST%20if%20the%20wrong%20number%20of%20arguments%20are%20passed%20in%20then%20the%20function%20will%20silently%20fail%20and%20never%20return%20an%20error.%20Please%20fix.%22%2C%20%22created_at%22%3A%20%222015-08-24T22%3A31%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22changed%22%2C%20%22created_at%22%3A%20%222015-08-25T08%3A00%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-26T18%3A53%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/JXcoreExtension.java%3AL4-34%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%2084%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37355798%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20This%20method%20really%20confuses%20me.%20I%20thought%20that%20you%20said%20that%20BlueTooth%20supports%20connecting%20to%20multiple%20different%20devices%20simultaneously.%20But%20this%20Disconnect%20method%20seems%20to%20assume%20that%20we%20will%20only%20connect%20to%20a%20single%20peer%20at%20a%20time.%20What%20am%20I%20missing%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A27%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20I%20realize%20this%20will%20now%20be%20fixed%20in%200.8%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A54%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL76-94%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20156%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37358650%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20I%20would%20suggest%20that%20the%20code%20would%20be%20easier%20to%20read%20if%20you%20just%20stuck%20a%20return%20after%20line%20204.%20That%20would%20allow%20you%20to%20get%20rid%20of%20the%20next%20else%20and%20indent%20all%20of%20that%20code%20one%20tab%20space%20to%20the%20left.%20It%27s%20easier%20to%20read%20code%20that%20isn%27t%20deeply%20nested.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A54%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T23%3A00%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL194-226%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20155%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37358570%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20This%20assumes%20that%20we%20can%20connect%20to%20only%20one%20peer%20at%20a%20time.%20But%20I%20thought%20you%20said%20that%20Bluetooth%20supports%20multiple%20simultaneous%20connections%20to%20different%20peers%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A53%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20To%20be%20fixed%20in%200.8%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A59%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL194-226%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20thali/thalireplicationmanager.js%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37364572%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20seems%20like%20this%20code%20is%20assuming%20that%20PEER_AVAILABILITY_CHANGED%20will%20always%20return%20all%20peers%20that%20are%20current%20visible%3F%20But%20in%20looking%20%5Bhere%5D%28https%3A//github.com/thaliproject/Thali_CordovaPlugin/blob/story_0/doc/api/connectivity.md%29%20it%20only%20says%20that%20the%20event%20will%20be%20called%20when%20a%20peer%27s%20availability%20changes.%20Which%20implies%20that%20if%20a%20peer%27s%20availability%20hasn%27t%20changed%20then%20it%20won%27t%20be%20included%20in%20the%20event.%20In%20which%20case%20we%20just%20overwrite%20this._peers%20with%20an%20incomplete%20list%20of%20who%20is%20available%21%20That%20doesn%27t%20sound%20right.%20What%20am%20I%20missing%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T23%3A07%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20as%20per%20suggestion%20with%20the%20following%3A%5Cr%5Cn%60%60%60js%5Cr%5Cn%20%20this._peers%20%3D%20peers.reduce%28function%20%28acc%2C%20peer%29%20%7B%5Cr%5Cn%20%20%20%20acc%5Bpeer.peerIdentifier%5D%20%3D%20peer%3B%20return%20acc%3B%5Cr%5Cn%20%20%7D%2C%20this._peers%29%3B%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-08-19T20%3A11%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A10%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL117-149%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37355581%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20I%20don%27t%20believe%20this%20is%20safe.%20You%20can%27t%20synchronize%20on%20an%20object%20that%20can%20become%20null%2C%20I%20believe%20it%20will%20cause%20an%20exception.%20A%20much%20simpler%20approach%20is%20to%20just%20make%20a%20local%20copy%20of%20mBtToRequestSocket%20and%20then%20test%20if%20the%20local%20copy%20is%20null%20and%20issue%20methods%20based%20on%20that.%20This%20assumes%2C%20of%20course%20that%20all%20of%20mBtToRequestSocket%27s%20methods%20are%20thread%20safe%20but%20of%20course%20they%20should%20be%20given%20our%20asynchronous%20environment.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A25%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A53%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL97-112%22%7D%2C%20%22Pull%20303ae2ac9921143683c569d7046cd50f0da23b12%20thali/thalireplicationmanager.js%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36888127%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22/sockiet/socket/%22%2C%20%22created_at%22%3A%20%222015-08-12T17%3A26%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222015-08-12T18%3A09%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-13T16%3A02%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL202-246%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20123%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37442700%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20we%20make%20mServerSocketList%20final%20then%20it%20can%20never%20be%20null%2C%20only%20empty.%22%2C%20%22created_at%22%3A%20%222015-08-19T17%3A31%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A23%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL74-151%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20106%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37441413%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20use%20of%20an%20empty%20string%20to%20mean%20disconnect%20really%20worries%20me.%20Mostly%20because%20this%20means%20that%20if%20someone%20in%20node.js%20land%20calls%20disconnect%20with%20an%20empty%20string%20that%20will%20also%20cause%20the%20current%20peer%20to%20disconnect.%20That%20is%20a%20great%20way%20to%20create%20really%20bad%20bugs.%20We%20should%20always%20make%20the%20programmer%20be%20explicit%20about%20their%20desire.%20So%20I%20would%20remove%20the%20%5C%22%5C%22%20flag%20%28which%20anyway%20is%20ambiguous%29%20and%20create%20a%20private%20method%20%5C%22DisconnectAll%5C%22%20that%20Stop%20can%20call%20and%20make%20Disconnect%20%5C%22safe%5C%22%20by%20requiring%20an%20exact%20peerid%20match.%22%2C%20%22created_at%22%3A%20%222015-08-19T17%3A19%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A22%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL74-151%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23issuecomment-135132763%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5Cn%5Cn%5CnReview%20status%3A%200%20of%2013%20files%20reviewed%20at%20latest%20revision%2C%201%20unresolved%20discussion%2C%20all%20commit%20checks%20successful.%5Cn%5Cn---%5Cn%5Cn%3Csup%3E%2A%2A%5Bsrc/android/java/io/jxcore/node/BtConnectorHelper.java%2C%20line%2012%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/thaliproject/thali_cordovaplugin/69%23-JxfGzz5gZRuseGY_pXs%29%2A%2A%20%28%5Braw%20file%5D%28https%3A//github.com/thaliproject/thali_cordovaplugin/blob/bdce7ef4f9230903ffc0a690180ccd4b7239d2f0/src/android/java/io/jxcore/node/BtConnectorHelper.java%23L12%29%29%3A%3C/sup%3E%5CnThis%20is%20a%20comment.%20Please%20ignore%20it.%20I%27m%20testing%20reviewable.io.%5Cn%5Cn---%5Cn%5Cn%5CnComments%20from%20the%20%5Breview%20on%20Reviewable.io%5D%28https%3A//reviewable.io%3A443/reviews/thaliproject/thali_cordovaplugin/69%29%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-26T18%3A33%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-26T19%3A01%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20187%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37359656%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20On%20line%20236%20above%20/conenctivity/connectivity/%22%2C%20%22created_at%22%3A%20%222015-08-18T22%3A05%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40DrJukka%20On%20line%20248%20what%20happens%20if%20bluetoothSocket%20is%20null%3F%20Currently%20the%20code%20does%20nothing.%20That%20is%20fine%20but%20in%20that%20case%20please%20rewrite%20the%20code%20to%20check%20for%20null%20and%20return%20and%20then%20out%20indent%20the%20rest%20of%20the%20code.%20I%27ll%20stop%20making%20this%20comment%20about%20%27if%27%20styling%20%28e.g.%20don%27t%20indent%20things%20like%20crazy%2C%20instead%20use%20return%29%20and%20assume%20you%20will%20check%20all%20your%20files%20for%20it%20and%20please%20fix.%22%2C%20%22created_at%22%3A%20%222015-08-18T22%3A07%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40DrJukka%20The%20connected%20method%20is%2C%20I%20think%2C%20unnecessarily%20hard%20to%20read.%20Could%20you%20please%20refactor%20it%20into%20two%20methods%2C%20one%20called%20ConnectedIncoming%20and%20another%20called%20ConnectedOutgoing%20and%20whomever%20calls%20this%20can%20then%20switch%20between%20the%20two%20based%20on%20the%20incoming%20value%3F%20It%20would%20make%20the%20code%20much%20easier%20to%20read.%22%2C%20%22created_at%22%3A%20%222015-08-18T22%3A08%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20Connected%20method%20is%20re-Structured%20for%20better%20readability.%22%2C%20%22created_at%22%3A%20%222015-08-24T07%3A15%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A13%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL241-262%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%2031%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37353843%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20am%20very%20concerned%20that%20the%20approach%20of%20wrapping%20lastAvailableList%20in%20a%20synchronized%20is%20too%20error%20prone.%20If%20someone%2C%20somewhere%20ever%20forgets%20to%20protect%20lastAvailableList%20it%20all%20goes%20bad.%20Please%20replace%20this%20use%20of%20synchronized%20and%20make%20lastAvailableList%20into%20a%20CopyOnWriteArrayList%20or%20equivalent.%20The%20overhead%20of%20copying%20the%20array%27s%20contents%20shouldn%27t%20matter%20given%20the%20physical%20limitations%20on%20how%20many%20devices%20we%20can%20potentially%20discover.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A09%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40DrJukka%20Just%20adding%20your%20tag%20sign%20so%20you%20get%20notified%20since%20this%20comment%20is%20in%20your%20code.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A11%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A47%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL55-75%22%7D%2C%20%22Pull%20303ae2ac9921143683c569d7046cd50f0da23b12%20thali/thalireplicationmanager.js%2036%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36887935%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20if%20we%20didn%27t%20get%20an%20error%20on%20the%20disconnect%3F%20In%20that%20case%20won%27t%20err%20be%20null%3F%20Shouldn%27t%20we%20check%20for%20that%20and%20only%20run%20line%20169%20and%20170%20if%20there%20is%20an%20actual%20error%3F%22%2C%20%22created_at%22%3A%20%222015-08-12T17%3A25%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20as%20per%20latest%20commit%22%2C%20%22created_at%22%3A%20%222015-08-12T18%3A09%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-13T15%3A59%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL166-185%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20273%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37448144%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Might%20it%20make%20sense%20to%20make%20lastAvailableList%20into%20something%20like%20a%20ConcurrentHashMap%3F%20No%20need%20to%20implement%20your%20own%20search%20function.%20Entries%20could%20be%20added%20based%20on%20peerId.%22%2C%20%22created_at%22%3A%20%222015-08-19T18%3A14%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20I%27m%20giving%20up%20on%20this%20for%20now%20but%20when%20I%20next%20have%20my%20hand%20in%20the%20code%20I%27m%20fixing%20this%21%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A01%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL155-296%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/BtToServerSocket.java%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37811334%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22A%20lot%20of%20my%20comments%20from%20BtToRequestSocket%20apply%20here%20since%20the%20code%20is%20so%20similar.%20This%20includes%20everything%20from%20never%20catching%20the%20Exception%20object%20to%20guarding%20start%20and%20stop%20via%20mStopped%20to%20making%20mHTTPPort%20into%20an%20accessor%20method%20to%20making%20sure%20we%20properly%20re-throw%20exceptions%20rather%20than%20silently%20swallow%20them%2C%20etc.%22%2C%20%22created_at%22%3A%20%222015-08-24T22%3A13%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22For%20catch-%20lets%20chat%2C%20and%20I%27ll%20fix%20things%20if%20needed%20really%20quickly%20after%20the%20chat.%20For%20mHTTPPort%2C%20in%20this%20case%20we%20are%20actually%20getting%20port%20externally%20set%2C%20so%20we%20need%20to%20use%20variable%20in%20here.%22%2C%20%22created_at%22%3A%20%222015-08-25T06%3A56%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22Did%20actually%20move%20the%20stuff%20back%20to%20constructor%2C%20also%20made%20it%20throwing%20the%20Exception.%20Needed%20this%20when%20I%20got%20to%20the%20restructuring%20phase%2C%20the%20throwing%20code%20is%20now%20in%20base%20class.%22%2C%20%22created_at%22%3A%20%222015-08-25T07%3A44%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-26T18%3A51%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToServerSocket.java%3AL13-52%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20thali/thalireplicationmanager.js%20153%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37365290%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Isn%27t%20this%20assuming%20that%20we%20can%20only%20be%20in%20retry%20with%20a%20single%20peer%20at%20a%20time%3F%20What%20if%20we%20have%20multiple%20peers%20we%20are%20simultaneously%20connecting%20to%20and%20we%20are%20in%20retry%20with%20one%20or%20more%20of%20them%3F%20Shouldn%27t%20isInRetry%20really%20be%20an%20array%20indexed%20by%20peerID%3F%5Cr%5Cn%5Cr%5CnAlso%20while%20on%20the%20topic%20can%20we%20take%20clients%20and%20replications%20and%20the%20rest%20and%20collapse%20them%20into%20one%20array%20with%20an%20object%3F%20It%20would%20make%20it%20much%20easier%20to%20think%20about%20threading%20issues%20since%20all%20the%20places%20state%20can%20blow%20up%20are%20in%20one%20place%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T23%3A19%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20I%27m%20going%20to%20assume%20this%20will%20get%20fixed%20in%20story%200.8.%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A11%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL185-308%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20264%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37447644%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20sure%20what%20the%20error%20should%20be%20in%20this%20case%20but%20I%20don%27t%20think%20this%20is%20it.%20I%20would%20expect%20a%20standard%20error%2C%20defined%20in%20the%20doc%20file%2C%20of%20the%20form%20like%20%5C%22Maximum%20peer%20connections%20reached%2C%20please%20try%20again%20after%20disconnecting%20a%20peer.%5C%22%22%2C%20%22created_at%22%3A%20%222015-08-19T18%3A10%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A59%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL155-296%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtToRequestSocket.java%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37474148%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Question%20-%20why%20is%20there%20a%20setPort%20method%3F%20We%20only%20seem%20to%20call%20it%20in%20one%20place%20and%20we%20always%20pass%200.%20Wouldn%27t%20it%20be%20easier%20to%20just%20include%20the%20port%20in%20the%20constructor%3F%20Or%20better%20yet%2C%20never%20include%20a%20port%20at%20all%20and%20always%20have%20it%20be%200%3F%20If%20we%20set%20it%20in%20the%20constructor%20then%20we%20can%20make%20mHTTPPort%20final%20and%20that%20is%20always%20a%20good%20thing.%22%2C%20%22created_at%22%3A%20%222015-08-19T21%3A59%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40DrJukka%20I%27d%20like%20to%20see%20a%20response%20to%20this%20issue.%20Thanks%21%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A03%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-25T18%3A53%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL170-262%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37446744%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20Please%20do%20me%20a%20favor.%20Follow%20the%20team%20read%20me%20instructions%20to%20set%20up%20ThaliTest.%20Then%20open%20up%20IntelliJ%20and%20go%20to%20file-%3Eopen%20and%20point%20it%20to%20the%20build.gradle%20file%20in%20ThaliTest/platforms/android.%20Then%20go%20to%20Analyze-%3EInspect%20Code%20and%20choose%20custom%20scope%2C%20choose%20local%20and%20then%20select%20the%20android/src%20directory%20and%20hit%20%27Include%20Recursively%27.%20You%20should%20see%20a%20pattern%20of%20the%20form%20%60file%5Bandroid%5D%3Asrc//%2A%60%20then%20hit%20OK%20and%20run%20the%20analysis.%20Then%20start%20looking%20through%20the%20analysis.%20Not%20everything%20it%20calls%20out%20is%20relevant%20%28for%20example%2C%20it%20catches%20some%20issues%20with%20JXcore%29%20and%20not%20all%20of%20its%20suggestions%20are%20necessary%20but%20it%20found%20a%20bunch%20of%20really%20obvious%20errors.%20I%20would%20appreciate%20it%20if%20you%20could%20run%20it%20so%20that%20I%20don%27t%20have%20to%20even%20think%20about%20those%20classes%20of%20errors%20and%20can%20just%20look%20at%20the%20code.%20Thanks%21%5Cr%5Cn%5Cr%5CnOh%2C%20one%20more%20thing.%20Before%20you%20run%20the%20analysis%20go%20to%20file-%3Eproject%20structure-%3Eproject%20and%20set%20the%20Project%20SDK%20to%20Android%20and%20set%20the%20project%20language%20level%20to%207.%20This%20will%20prevent%20some%20spurious%20suggestions.%5Cr%5Cn%5Cr%5CnBut%20please%20do%20this.%20It%20will%20clean%20up%20spelling%20errors.%20Inefficient%20Ifs.%20Spurious%20variables.%20Unused%20methods.%20Etc.%20Having%20all%20this%20cleaned%20up%20before%20a%20code%20review%20makes%20for%20a%20much%20more%20efficient%20code%20review.%5Cr%5Cn%5Cr%5CnBut%20remember%2C%20suggestions%20aren%27t%20orders%20and%20some%20of%20their%20suggestions%20can%20make%20things%20worse.%20You%20have%20to%20keep%20your%20wits%20about%20you%20and%20make%20sure%20that%20their%20suggestions%20actually%20make%20sense%20given%20your%20goals%20for%20the%20code.%20This%20is%20not%20a%20mechanical%20exercise.%20Think%20of%20it%20rather%20as%20hints.%20You%20need%20to%20think%20if%20you%20agree%20with%20the%20hints%20that%20IntelliJ%20gives.%5Cr%5Cn%5Cr%5CnThanks%21%22%2C%20%22created_at%22%3A%20%222015-08-19T18%3A03%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A37%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL5-25%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20220%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37444020%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20surprised%20this%20didn%27t%20cause%20a%20compiler%20error.%20This%20method%20returns%20a%20boolean%20but%20we%20are%20returning%20null%3F%20Null%20for%20a%20primitive%20type%3F%20In%20any%20case%20shouldn%27t%20this%20be%20%60return%20bluetooth%20%3D%3D%20null%20%3F%20false%20%3A%20bluetooth.setName%28name%29%60%3F%22%2C%20%22created_at%22%3A%20%222015-08-19T17%3A42%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A25%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL74-151%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20223%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37446927%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20best%20practice%20to%20put%20member%20variables%20at%20the%20top%20of%20the%20class%20definition.%20This%20lets%20people%20see%20at%20a%20glance%20all%20the%20state%20the%20class%20maintains.%22%2C%20%22created_at%22%3A%20%222015-08-19T18%3A04%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Oh%20well%2C%20win%20some%2C%20lose%20some.%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A38%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL74-151%22%7D%2C%20%22Pull%2014da11066eef648c3c4e4e46b6ef938a1a2d5378%20src/android/java/io/jxcore/node/BtToRequestSocket.java%2089%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37899296%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20must%20not%20ever%20catch%20Exception.%20This%20is%20pretty%20much%20always%20wrong%20%28in%20the%20same%20sense%20that%20using%20GOTOs%20is%20always%20wrong%2C%20except%2C%20in%20the%20few%20cases%20where%20it%20isn%27t%20and%20this%20isn%27t%20one%20of%20them%29.%20In%20this%20case%20the%20obvious%20problem%20is%20that%20run%20is%20on%20its%20own%20thread%20so%20any%20exceptions%20will%20be%20eaten%20by%20the%20thread%20if%20they%20aren%27t%20caught.%5Cr%5Cn%5Cr%5CnExcept%20Java%20has%20a%20specific%20feature%20to%20handle%20this%2C%20UncaughtExceptionHandler.%20This%20is%20a%20method%20on%20all%20Thread%20objects%20that%20lets%20you%20register%20a%20handler%20who%20will%20be%20called%20if%20the%20thread%20exits%20with%20an%20exception.%20That%20handler%20should%20then%20repeat%20the%20exception%20on%20the%20main%20thread.%20Yes%2C%20there%20are%20other%20mechanisms%20like%20the%20default%20unhandled%20exception%20handler%20but%20it%27s%20better%20hygiene%20to%20set%20handlers%20as%20low%20in%20the%20chain%20as%20possible.%5Cr%5Cn%5Cr%5CnThe%20idea%20is%20that%20this%20catch%20should%20only%20catch%20exceptions%20we%20are%20expecting%2C%20like%20ioExceptions.%20But%20by%20catching%20the%20root%20Exception%20object%20we%20also%20catch%20errors%20that%20are%20deadly%20serious%20and%20we%20must%20not%20catch%2C%20like%20RuntimeException%20and%20all%20of%20its%20children%20that%20include%20fun%20things%20like%20null%20pointer%20exceptions%20and%20indexing%20errors.%20The%20kind%20of%20exceptions%20that%20need%20to%20cause%20the%20program%20to%20fail%20because%20something%20has%20gone%20horribly%20wrong.%5Cr%5Cn%5Cr%5CnSo%20please%2C%20use%20UncaughtExceptionHandler%20on%20all%20of%20your%20thread%20objects%20in%20all%20of%20your%20classes%20and%20use%20a%20generic%20handler%20that%20just%20re-throws%20anything%20it%20gets%20onto%20the%20main%20thread.%20And%20please%20only%20catch%20here%20specific%20exceptions%20you%20should%20be%20looking%20for%20like%20ioExceptions.%22%2C%20%22created_at%22%3A%20%222015-08-25T18%3A14%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-26T19%3A00%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL11-103%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20227%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37447168%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20is%20this%20tmpCallback%20variable%20created%3F%20No%20one%20can%20change%20the%20pointer%20to%20connectStatusCallback%20from%20under%20you%20since%20it%27s%20local.%20And%20you%20don%27t%20use%20connectStatusCallback%20for%20anything%20but%20setting%20tmpCallback.%20So%20I%27m%20confused%20why%20it%27s%20here.%22%2C%20%22created_at%22%3A%20%222015-08-19T18%3A06%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A58%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL155-296%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20226%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37447066%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20one%20is%20really%20optional%20but%20when%20I%27m%20dealing%20with%20multi-threaded%20code%20I%20will%20tend%20to%20put%20a%20final%20on%20my%20method%20arguments%20%28e.g.%20final%20String%20toPeerId%29%20just%20to%20make%20sure%20they%20are%20immutable%20and%20I%20don%27t%20accidentally%20mess%20with%20them%20in%20the%20code.%20But%20this%20is%20a%20matter%20of%20taste.%22%2C%20%22created_at%22%3A%20%222015-08-19T18%3A05%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20BTW%2C%20you%20could%20also%20have%20put%20final%20on%20connectStatus.%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A57%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL155-296%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20122%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37357316%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20Instead%20of%20synchronizing%20on%20mServerSocketList%20we%20should%20use%20CopyOnWriteArrayList%20or%20equivalent.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A41%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A55%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL116-139%22%7D%2C%20%22Pull%2046695bbadbca984cb8cc01990db1527e9fd7c6b6%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20186%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37685313%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20This%20isn%27t%20the%20idiomatic%20way%20of%20handling%20this.%20As%20IntelliJ%20will%20automatically%20fix%20for%20you%20this%20should%20be%20written%20as%3A%5Cr%5Cn%5Cr%5Cn%60%60%60Java%5Cr%5Cnfor%20%28BtToServerSocket%20rSocket%20%3A%20mServerSocketList%29%20%7B%5Cr%5Cn%20%20%20...%5Cr%5Cn%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnBTW%2C%20you%20shouldn%27t%20need%20to%20test%20for%20null%20since%20as%20long%20as%20you%20use%20%27clear%27%20you%20will%20never%20have%20a%20null%20entry.%20If%20you%20are%20testing%20for%20null%20it%20should%20be%20for%20defensive%20purposes%20but%20in%20that%20case%20you%20should%20throw%20an%20exception%20or%20at%20least%20log%20something%20if%20you%20find%20a%20null%20since%20that%20would%20be%20an%20error.%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A47%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22changed%20it%20to%20be%20implemented%20as%20suggested%20by%20IntelliJ%22%2C%20%22created_at%22%3A%20%222015-08-24T07%3A07%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A40%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL51-332%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/BtToRequestSocket.java%20173%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37797690%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20you%20mark%20this%20as%20volatile%20and%20check%20it%20before%20stop%20and%20run%3F%20In%20other%20words%20if%20this%20is%20true%20when%20stop%20is%20called%20then%20clearly%20stop%20has%20been%20called%20twice.%20Similarly%20if%20this%20is%20true%20when%20start%20is%20called%20then%20start%20is%20being%20called%20after%20stop.%20Just%20make%20sure%20that%20member%20variable%20is%20volatile%20or%20you%20can%20end%20up%20with%20some%20odd%20race%20conditions.%22%2C%20%22created_at%22%3A%20%222015-08-24T20%3A06%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20did%20mark%20it%20as%20volatile.%20Basically%20Stop%20can%20be%20called%20multiple%20times%2C%20and%20there%20is%20no%20problem%20calling%20it%20before%20start%28%29.%20The%20run%28%29%20is%20called%20by%20the%20API.%20And%20supposedly%20%20the%20API%20is%20designed%20in%20a%20way%20that%20it%20will%20only%20be%20called%20once.%22%2C%20%22created_at%22%3A%20%222015-08-25T06%3A53%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fair%20point%20on%20run.%20But%20in%20that%20case%2C%20what%20purpose%20is%20mStopped%3F%20It%20gets%20set%20but%20near%20as%20I%20can%20tell%20it%20literally%20never%20gets%20checked.%20So%20why%20not%20just%20remove%20it%3F%22%2C%20%22created_at%22%3A%20%222015-08-25T18%3A50%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-26T18%3A45%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL150-239%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/BtToRequestSocket.java%20158%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37797557%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Per%20my%20previous%20suggestion%20I%20would%20actually%20get%20rid%20of%20mHTTPPort%20all%20together%20and%20just%20use%20GetLocalHostPort%20directly%20for%20everything%20and%20have%20it%20call%20the%20srvSocket%20and%20get%20the%20port%20directly.%22%2C%20%22created_at%22%3A%20%222015-08-24T20%3A04%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222015-08-25T06%3A50%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-25T18%3A48%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL150-239%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20124%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37357377%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20Note%20that%20when%20you%20switch%20to%20CopyOnWriteArrayList%20or%20equivalent%20you%20will%20want%20to%20use%20methods%20like%20elements%28%29%20to%20get%20a%20consistent%20set%20of%20contents%20to%20iterate%20over.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A41%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A55%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL116-139%22%7D%2C%20%22Pull%20c10d2e6341ce7528d45b8d1c82c423e712987b9c%20thali/thalireplicationmanager.js%2077%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37000591%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20we%20got%20an%20error%20on%20the%20clientSocket%20then%20hasn%27t%20it%20already%20destroyed%20itself%3F%22%2C%20%22created_at%22%3A%20%222015-08-13T17%3A23%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Destroying%20a%20socket%20is%20idempotent%20or%20at%20least%20should%20be%20according%20to%20my%20tests%22%2C%20%22created_at%22%3A%20%222015-08-18T18%3A57%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A05%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL206-250%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/BtToRequestSocket.java%20152%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37797327%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20line%20148%20below%20where%20you%20have%20the%20else%20in%20StreamCopyError%20shouldn%27t%20it%20also%20call%20mHandler.Disconnected%3F%20It%20seems%20like%20Disconnected%20is%20your%20flag%20that%20something%20awful%20has%20happened%20and%20getting%20called%20on%20StreamCopyError%20with%20an%20unknown%20thread%20would%20seem%20to%20qualify%20as%20horrible.%22%2C%20%22created_at%22%3A%20%222015-08-24T20%3A02%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sure%20I%20add%20it%20there%2C%20would%20though%20suppose%20that%20this%20should%20not%20be%20called.%20Though%2C%20current%20code%20should%20actually%20work%20also%20without%20stopping%20the%20SendingThread%20in%20that%20callback%20%28and%20just%20handling%20it%20in%20a%20stop%29%2C%20then%20I%20suppose%20the%20third%20option%20would%20never%20be%20called.%22%2C%20%22created_at%22%3A%20%222015-08-25T06%3A50%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-25T18%3A47%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL63-127%22%7D%2C%20%22Pull%20c10d2e6341ce7528d45b8d1c82c423e712987b9c%20thali/thalireplicationmanager.js%2072%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37000558%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20we%20get%20an%20error%20on%20the%20stream%20don%27t%20we%20need%20to%20shut%20down%20the%20clientSocket%3F%22%2C%20%22created_at%22%3A%20%222015-08-13T17%3A23%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20as%20per%20suggestion%22%2C%20%22created_at%22%3A%20%222015-08-18T18%3A56%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20confused.%20Now%20we%20don%27t%20seem%20to%20be%20tracking%20any%20errors%20what%20so%20ever%20on%20stream.%20That%20doesn%27t%20sound%20right.%22%2C%20%22created_at%22%3A%20%222015-08-18T23%3A29%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20removed%20the%20stream%20error%20handling%20because%20if%20that%20really%20goes%20bad%20then%20we%27ve%20got%20larger%20problems%20on%20our%20hand.%20%20And%20no%2C%20we%20don%27t%20want%20to%20tear%20that%20down%20else%20we%20get%20errors.%22%2C%20%22created_at%22%3A%20%222015-08-19T20%3A09%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A04%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL206-250%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20102%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37356404%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20suggest%20having%20a%20mBtToRequestSocket%20class%20that%20contains%20all%20the%20peers%20we%20are%20connected%20to%20and%20contains%20a%20method%20%27disconnectPeer%28peerId%29%27%20that%20will%20use%20a%20concurrent%20safe%20list%20with%20an%20atomic%20update%20and%20in%20that%20atomic%20update%20you%20would%20then%20check%20to%20see%20if%20the%20peerid%20exists%2C%20call%20close%20on%20the%20mBtToRequestSocket%20and%20then%20return%20null%20for%20the%20peer%20ID%27s%20state.%20I%20suspect%20this%20will%20be%20the%20most%20robust%20implementation%20that%20doesn%27t%20require%20a%20bunch%20of%20fiddly%20synchronized%20calls.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A32%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20To%20be%20fixed%20in%200.8%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A54%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL97-112%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20172%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37444651%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Since%20this%20method%20is%20only%20used%20inside%20of%20BtConnectorHelper%20wouldn%27t%20it%20be%20easier%20to%20make%20this%20method%20private%3F%5Cr%5Cn%5Cr%5CnIt%27s%20generally%20good%20defensive%20programming%20to%20make%20as%20many%20things%20private%20as%20you%20can.%20It%20reduces%20the%20number%20of%20places%20where%20it%20can%20cause%20trouble.%20Now%2C%20to%20be%20fair%2C%20this%20can%20be%20a%20pain%20when%20writing%20tests%20and%20sometimes%20one%20will%20either%20make%20things%20public%20or%20use%20protected%20for%20those%20purposes.%20But%20that%20doesn%27t%20apply%20here.%20So%20I%20would%20evaluate%20the%20methods%20and%20see%20what%20you%20can%20make%20private.%22%2C%20%22created_at%22%3A%20%222015-08-19T17%3A47%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A37%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL74-151%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20119%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37442588%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20comment%20is%20misleading%20since%20the%20method%20is%20also%20used%20by%20stop.%22%2C%20%22created_at%22%3A%20%222015-08-19T17%3A30%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A23%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL74-151%22%7D%2C%20%22Pull%20303ae2ac9921143683c569d7046cd50f0da23b12%20thali/thalireplicationmanager.js%2074%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36889852%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22/sockiet/socket/%22%2C%20%22created_at%22%3A%20%222015-08-12T17%3A40%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222015-08-12T18%3A08%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-13T16%3A03%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL202-246%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20thali/thalireplicationmanager.js%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37364290%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Purely%20as%20an%20example%20of%20defensive%20programming%20would%20it%20make%20sense%20to%20put%20a%20return%20after%20line%20114%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T23%3A03%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20as%20per%20comment%20with%20return%20stop%20and%20return%20start%22%2C%20%22created_at%22%3A%20%222015-08-19T20%3A12%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A08%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL106-116%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20thali/thalireplicationmanager.js%2058%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37364857%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20please%20use%20a%20slightly%20more%20informative%20variable%20name%20than%20p%3F%20Like%20existingPeerReplication%3F%20I%27m%20slow%20and%20keep%20getting%20confused%20between%20peer%20and%20p.%22%2C%20%22created_at%22%3A%20%222015-08-18T23%3A12%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22changed%20from%20p%20to%20existingReplication%22%2C%20%22created_at%22%3A%20%222015-08-19T20%3A14%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A10%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL117-149%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20137%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37443396%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20is%20super%20unsafe%20to%20iterate%20on%20a%20thread%20safe%20object%20using%20a%20counter%20since%20the%20membership%20can%20change%20during%20the%20iteration.%20You%20have%20to%20model%20this%20stuff%20in%20your%20head.%20On%20each%20method%20call%20you%20have%20to%20ask%20yourself%20%5C%22what%20happens%20if%20we%20have%20multiple%20simultaneous%20calls%3F%5C%22%20If%20multiple%20people%20can%20work%20on%20mServerSocketList%20at%20the%20same%20time%20then%20certainly%20while%20we%20are%20iterating%20on%20its%20membership%20that%20membership%20can%20change%21%20Also%20whenever%20using%20a%20new%20class%20you%20should%20always%20read%20its%20docs.%20The%20docs%20on%20CopyOnWriteArrayList%20%28see%20%5Bhere%5D%28http%3A//docs.oracle.com/javase/7/docs/api/java/util/concurrent/CopyOnWriteArrayList.html%29%29%20explicitly%20calls%20out%20the%20fact%20that%20it%20uses%20a%20snapshot%20style%20iterator%20to%20handle%20exactly%20this%20problem.%20So%20what%20you%20need%20to%20do%20is%20to%20call%20either%20iterator%28%29%20or%20listIterator%28%29%20in%20order%20to%20get%20a%20thread%20safe%20snap%20shot%20of%20the%20list%27s%20contents%20and%20iterate%20on%20that.%5Cr%5Cn%5Cr%5CnAlso%20using%20that%20iterator%20should%20simplify%20the%20code%20below%20since%2C%20for%20example%2C%20you%20don%27t%20need%20to%20check%20for%20null.%20You%20should%20never%20be%20putting%20nulls%20into%20the%20list.%20Instead%20when%20you%20want%20to%20remove%20a%20member%20you%20should%20call%20remove.%20Keep%20in%20mind%2C%20btw%2C%20that%20you%20should%20NEVER%20remove%20by%20index.%20It%27s%20never%20safe.%20I%27m%20shocked%20they%20even%20offer%20it%20as%20an%20option.%5Cr%5Cn%5Cr%5CnIn%20fact%2C%20if%20I%20were%20you%2C%20since%20order%20doesn%27t%20matter%20to%20either%20lastAvailableList%20or%20mServerSocketList%20I%20would%20urge%20you%20to%20consider%20changing%20both%20variables%20to%20be%20of%20type%20CopyOnWriteArraySet.%20This%20will%20remove%20most%20of%20the%20really%20unsafe%20methods%20and%20make%20it%20easier%20to%20write%20correct%20code.%22%2C%20%22created_at%22%3A%20%222015-08-19T17%3A36%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A24%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL74-151%22%7D%2C%20%22Pull%20303ae2ac9921143683c569d7046cd50f0da23b12%20thali/thalireplicationmanager.js%2070%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36888421%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20do%20you%20destroy%20the%20incomingClientSocket%20on%20error%20but%20not%20on%20end%3F%20%20Of%20course%20given%20my%20previous%20question%20about%20destroying%20%5C%22end%5C%22ed%20sockets%20maybe%20this%20is%20correct%20and%20line%20207%20is%20the%20problem%3F%22%2C%20%22created_at%22%3A%20%222015-08-12T17%3A28%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20on%20the%20assumption%20that%20end%20is%20perfectly%20normal%20but%20error%20is%20not.%20%20Pretty%20sure%20we%20can%20get%20rid%20of%20that%20code%20for%20destroying%20the%20socket%20because%20an%20error%20should%20do%20that%20already.%20%20However%2C%20on%20stream%20error%20we%20might%20want%20to%20tear%20down%20the%20incoming%20client%20socket%22%2C%20%22created_at%22%3A%20%222015-08-13T16%3A17%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Please%20tell%20me%20there%20are%20tests%20to%20be%20sure%20you%20are%20right%3F%22%2C%20%22created_at%22%3A%20%222015-08-13T17%3A20%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL202-246%22%7D%2C%20%22Pull%20303ae2ac9921143683c569d7046cd50f0da23b12%20thali/thalireplicationmanager.js%2058%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r36888210%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20we%20got%20an%20end%20event%20doesn%27t%20that%20mean%20the%20socket%20is%20already%20destroyed%3F%20Any%20danger%20from%20destroying%20a%20socket%20twice%3F%22%2C%20%22created_at%22%3A%20%222015-08-12T17%3A27%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20haven%27t%20noticed%20any%20exceptions%20being%20thrown%20from%20this%20code%2C%20so%20I%27m%20not%20sure%22%2C%20%22created_at%22%3A%20%222015-08-12T18%3A09%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20not%20just%20write%20a%20quick%20test%20to%20be%20sure%3F%20E.g.%20open%20a%20socket%2C%20destroy%20it%20and%20then%20destroy%20it%20again.%20It%27s%20best%20to%20be%20sure.%22%2C%20%22created_at%22%3A%20%222015-08-13T16%3A03%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20Per%20our%20conversation%22%2C%20%22created_at%22%3A%20%222015-08-13T17%3A19%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL202-246%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/BtToRequestSocket.java%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37795976%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Below%20you%20try%20to%20get%20mmSocket.getInputStream%20and%20getOutputStream.%20If%20they%20fail%20then%20an%20exception%20is%20thrown.%5Cr%5Cn%5Cr%5CnFirst%2C%20it%20is%20an%20extremely%20bad%20idea%20to%20ever%20catch%20Exception%20directly.%20This%20hides%20lots%20of%20bad%20things.%20See%20%5Bhere%5D%28http%3A//www.javaworld.com/article/2073800/testing-debugging/beware-the-dangers-of-generic-exceptions.html%29%20for%20why%20this%20is%20a%20bad%20idea.%20Please%20replace%20the%20catch%20with%20the%20specific%20Exception%28s%29%20being%20thrown.%5Cr%5Cn%5Cr%5CnSecond%2C%20why%20are%20we%20allowing%20the%20object%20to%20continue%20happily%20on%20its%20way%20when%20two%20key%20structures%20can%27t%20be%20retrieved%3F%20The%20object%20needs%20to%20go%20into%20some%20bad%20state.%20I%27d%20actually%20argue%20that%20the%20right%20thing%20to%20do%20is%20to%20just%20throw%20the%20exception%20and%20let%20Connected%20in%20BtConnectorHelper%20handle%20it.%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A52%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20see%20the%20point%20you%20are%20expressing.%20Each%20catch%20is%20calling%20Disconnected%28%29%2C%20which%20will%20clean%20up%20the%20class%20instance%20in%20BtConnectorHelper%20side.%20Also%20right%20after%20calling%20Disconnected%20there%20is%20return%3B%20which%20stops%20the%20execution%20of%20run.%22%2C%20%22created_at%22%3A%20%222015-08-25T06%3A31%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20now%20I%20understood%20that%20its%20was%20not%20the%20run%2C%20but%20the%20constructor%20you%20were%20referring%20to.%20I%20moved%20the%20code%20to%20Run%2C%20as%20I%20think%20I%20did%20with%20the%20BtToServerSocket%20already%20earlier.%22%2C%20%22created_at%22%3A%20%222015-08-25T06%3A34%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-25T18%3A30%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL38-45%22%7D%2C%20%22Pull%2046695bbadbca984cb8cc01990db1527e9fd7c6b6%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20327%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37686263%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20whole%20section%20from%20178%20to%20188%20should%20be%20replaced%20with%20a%20switch%20statement.%20This%20is%20literally%20what%20they%20were%20invented%20for.%5Cr%5Cn%5Cr%5Cn%60%60%60Java%5Cr%5Cn%20%20%20%20%20%20%20%20switch%20%28tmpConn.TryConnect%28selectedDevice%29%29%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20case%20Connecting%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20mConnectStatusCallback%20%3D%20connectStatusCallback%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%3B%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20etc.%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20default%3A%20throw%20new%20RuntimeException%28%5C%22Unrecognized%20enum%20type%21%5C%22%29%3B%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-08-21T23%3A06%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222015-08-24T07%3A11%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A41%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL51-332%22%7D%2C%20%22Pull%2014da11066eef648c3c4e4e46b6ef938a1a2d5378%20src/android/java/io/jxcore/node/BtToSocketBase.java%20144%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37901398%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20understand%20why%20this%20function%20exists.%20Why%20can%27t%20we%20just%20use%20Log.i%20everywhere%3F%22%2C%20%22created_at%22%3A%20%222015-08-25T18%3A30%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-26T19%3A00%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToSocketBase.java%3AL1-148%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20195%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37359026%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20This%20comment%20is%20in%20regards%20to%20line%20239%20above%20where%20you%20return%20%5C%22Device%20Address%20for%20....%20not%20found%20from%20Discovered%20device%20list%5C%22.%20The%20code%2C%20I%20believe%2C%20would%20be%20easier%20to%20read%20if%20you%20instead%20put%20in%5Cr%5Cn%5Cr%5Cn%60%60%60java%5Cr%5Cnif%20%28selectedDevice%20%3D%3D%20null%29%20%7B%5Cr%5Cn%20%20tmpCallback.ConnectionStatusUpdate%28%5C%22Device%20Address%20for%20%5C%22%20%2B%20toPeerId%20%2B%20%5C%22%20not%20found%20from%20Discovered%20device%20list.%5C%22%2C-1%29%3B%5Cr%5Cn%20%20return%3B%5Cr%5Cn%7D%5Cr%5Cn%60%60%60%5Cr%5CnThen%20you%20can%20remove%20the%20%60if%20%28selectedDevice%20%21%3D%20null%29%60%20and%20out%20indent%20that%20code.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A58%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T23%3A07%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL241-262%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/JXcoreExtension.java%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37812889%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20file%20could%20really%20use%20some%20re-factoring%20when%20it%20comes%20to%20if%20statements.%20There%20are%20several%20examples%20where%20you%20have%20big%20if%20statements%20followed%20by%20a%20tiny%20else%20%28usually%20an%20error%29.%20Just%20checking%20for%20the%20error%20upfront%20and%20then%20de-indenting%20the%20main%20if%20would%20make%20for%20more%20readable%20code.%22%2C%20%22created_at%22%3A%20%222015-08-24T22%3A29%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222015-08-26T12%3A01%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-26T18%3A53%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/JXcoreExtension.java%3AL4-34%22%7D%2C%20%22Pull%204ad4e709a8fb1ed9fce29ac6135b57a16b488c6f%20thali/thalireplicationmanager.js%2073%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37127600%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20this%20be%20before%20line%20206%3F%20I%20realize%20that%20given%20the%20single%20threaded%20nature%20of%20Javascript%20it%20shouldn%27t%20theoretically%20be%20possible%20for%20the%20event%20to%20be%20emitted%20before%20the%20handler%20is%20registered%20but%20boy%20do%20I%20hate%20tempting%20the%20gods.%5Cr%5Cn%5Cr%5CnAlso%20shouldn%27t%20this%20be%20once%20not%20on%3F%20Otherwise%20won%27t%20this%20will%20get%20called%20on%20EVERY%20stopped%20event%20which%20means%20that%20theoretically%20it%20isn%27t%20possible%20to%20ever%20stop%20the%20replication%20manager%3F%5Cr%5Cn%5Cr%5CnOh%20and%20what%20happens%20if%20we%20get%20a%20STOP_ERROR%3F%20Should%20we%20really%20not%20try%20to%20start%20again%3F%22%2C%20%22created_at%22%3A%20%222015-08-14T23%3A11%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20as%20per%20suggestion%22%2C%20%22created_at%22%3A%20%222015-08-18T18%3A57%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A06%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL202-264%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37438768%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20really%20want%20to%20make%20this%20final%20as%20well.%20%20Life%20is%20much%20easier%20if%20a%20variable%20can%20never%20go%20null.%20In%20the%20case%20of%20lastAvailableList%2C%20for%20example%2C%20the%20only%20place%20you%20ever%20reset%20it%20is%20in%20AddPeerIfNotDiscovered%20and%20you%20can%20just%20call%20the%20clear%20method%20on%20the%20variable.%5Cr%5Cn%5Cr%5CnTo%20be%20clear%2C%20you%20do%20NOT%20have%20a%20bug%20here.%20The%20code%20is%20correct.%20The%20use%20of%20final%20and%20clear%20is%20just%20meant%20as%20a%20defensive%20coding%20technique.%22%2C%20%22created_at%22%3A%20%222015-08-19T16%3A57%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A18%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL32-44%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20146%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37359460%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20What%20happens%20if%20BeginConnectPeer%20is%20called%20twice%20in%20parallel%3F%20This%20is%20perfectly%20reasonable%20if%20we%20are%20trying%20to%20connect%20to%20two%20different%20peers.%20I%27m%20fairly%20confident%20that%20making%20the%20method%20synchronized%20is%20not%20the%20right%20solution.%20This%2C%20for%20example%2C%20won%27t%20solve%20what%20happens%20if%20someone%20tries%20to%20simultaneously%20connect%20and%20disconnect%20since%20synchronized%20methods%20apply%20to%20repeated%20calls%20to%20the%20method%2C%20not%20the%20object.%20I%5C%22m%20not%20worried%20about%20race%20conditions%20as%20much%20as%20I%27m%20worried%20about%20us%20trying%20to%20connect%20to%20the%20same%20peer%20twice.%20Will%20Bluetooth%27s%20layer%20stop%20that%3F%20Or%20can%20you%20open%20two%20Bluetooth%20client%20sockets%20to%20the%20same%20device%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T22%3A02%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20To%20be%20solved%20in%200.8%22%2C%20%22created_at%22%3A%20%222015-08-21T23%3A07%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL194-226%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/BtToRequestSocket.java%2054%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37797058%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Per%20my%20previous%20comment%20please%20don%27t%20ever%20catch%20Exception%20directly.%20Also%20we%20shouldn%27t%20just%20quietly%20fail.%20Instead%20we%20should%20throw.%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A59%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22lets%20have%20a%20chat%20on%20this.%20Basically%20its%20not%20quietly%20failing.%20Its%20catching%20an%20Exception%20and%20reporting%20it%20%28which%20is%20causing%20cleanup%29%20and%20then%20stopping.%22%2C%20%22created_at%22%3A%20%222015-08-25T06%3A44%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22after%20re-structuring%20its%20now%20throwing%20exception%22%2C%20%22created_at%22%3A%20%222015-08-25T07%3A45%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5Cn%5Cr%5CnI%27m%20closing%20this%20comment%20because%20I%20opened%20a%20separate%20one%20where%20I%20call%20out%20the%20reasons%20why%20I%20believe%20that%20even%20the%20new%20Exception%20code%20is%20unfortunately%20not%20quite%20right.%22%2C%20%22created_at%22%3A%20%222015-08-25T18%3A39%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL63-127%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37440232%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Here%20is%20a%20fun%20example%20of%20why%20sometimes%20you%20have%20to%20use%20synchronized%20methods.%20Ask%20yourself%20the%20following%20question%20-%20what%20happens%20if%20start%20and%20stop%20both%20get%20called%20at%20the%20same%20time%20from%20different%20threads%3F%5Cr%5Cn%5Cr%5CnBut%20here%20is%20a%20better%20question%20-%20is%20it%20possible%20for%20start%20and%20stop%20to%20be%20called%20at%20the%20same%20time%20from%20different%20threads%3F%20I%20don%27t%20think%20so.%20But%20we%20should%20be%20sure.%20Here%20is%20my%20reasoning%20-%20The%20only%20entity%20that%20should%20EVER%20call%20BtConnectorHelper%20is%20JXcoreExtension%20and%20JXcore%20guarantees%20that%20JXcoreExtension%20will%20always%20be%20called%20on%20the%20same%20thread%20%28at%20least%20I%20think%20it%20guarantees%20that%2C%20we%20should%20check%20with%20Oguz%29.%20In%20that%20case%20methods%20like%20start%20and%20stop%20can%20only%20be%20called%20on%20a%20single%20thread%20since%20only%20JXcoreExtension%20can%20call%20them.%20If%20that%20is%20all%20true%20then%20this%20is%20worth%20some%20kind%20of%20comment%20at%20the%20top%20of%20the%20file%20pointing%20out%20that%20we%20are%20depending%20on%20the%20fact%20that%20other%20than%20in%20callbacks%20all%20the%20methods%20in%20BtConnectorHelper%20will%20only%20be%20called%20by%20JXcoreExtension%20and%20JXcoreExtension%20will%20only%20be%20called%20from%20the%20same%20thread.%22%2C%20%22created_at%22%3A%20%222015-08-19T17%3A10%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A20%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL52-70%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37438236%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22On%20line%2028%20below%20you%20set%20context%20to%20null.%20Which%20is%20fine%20but%20since%20context%20is%20only%20set%20in%20the%20constructor%20you%20can%20make%20it%20final.%20It%27s%20always%20good%20habit%20in%20multi-threaded%20code%20to%20make%20anything%20that%20can%20be%20final%2C%20into%20final%2C%20it%20prevents%20mistakes.%20So%20i%20would%20review%20all%20your%20state%20variables%20and%20see%20which%20ones%20you%20can%20make%20final.%22%2C%20%22created_at%22%3A%20%222015-08-19T16%3A52%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222015-08-24T06%3A59%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A18%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A18%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL5-25%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37355139%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Does%20it%20ever%20make%20sense%20for%20start%20to%20be%20called%20twice%20on%20the%20same%20BtConnectorHelper%20object%3F%20If%20not%20then%20I%20would%20suggest%20that%20we%20can%20get%20rid%20of%20synchronized%20and%20instead%20just%20use%20AtomicBoolean%20to%20stick%20in%20a%20guard%20and%20call%20it%20a%20day.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A20%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5CnBTW%2C%20we%20really%20need%20an%20atomic%20guard%20here%20so%20we%20can%20prevent%20someone%20accidentally%20calling%20startBroadcast%20twice%20without%20waiting%20for%20the%20callback.%20We%20should%20get%20an%20error%20on%20the%20second%20startBroadcast.%20But%20we%20can%20fix%20this%20later%20when%20I%20add%20a%20test%20for%20it.%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A03%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL55-75%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/BtToRequestSocket.java%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37796358%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20already%20set%20this%20in%20the%20constructor.%20Why%20set%20it%20again%20here%3F%20You%20already%20know%20it%27s%20zero.%5Cr%5Cn%5Cr%5CnAlso%2C%20how%20do%20you%20protect%20yourself%20against%20Run%20being%20called%20twice%3F%20I%20would%20just%20have%20a%20%27running%27%20boolean%20%28note%20the%20primitive%20type%2C%20not%20the%20class%20Boolean%29%20marked%20as%20volatile.%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A54%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22removed%20the%20variable.%5Cr%5Cn%5Cr%5CnI%20would%20assume%20that%20the%20Java-Thread%20itself%2C%20can%20not%20be%20started%20twice%3A%20http%3A//stackoverflow.com/questions/1215548/is-it-legal-to-call-the-start-method-twice-on-the-same-thread%22%2C%20%22created_at%22%3A%20%222015-08-25T06%3A40%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5Cn%5Cr%5CnYup%2C%20the%20comment%20on%20run%20was%20my%20bad.%20I%20was%20thinking%20of%20start%20which%20we%20use%20in%20other%20places.%20Sorry.%22%2C%20%22created_at%22%3A%20%222015-08-25T18%3A31%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL63-127%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtToRequestSocket.java%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37478913%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22From%20a%20style%20perspective%20I%20would%20have%20done%20something%20like%5Cr%5Cn%60%60%60Java%5Cr%5Cnreturn%20localHostSocket%20%3D%3D%20null%20%7C%7C%20localHostSocket.getInetAddress%28%29%20%3D%3D%20null%20%3F%20null%20%3A%20localHostSocket.getInetAddress%28%29.toString%28%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnAlthough%20to%20be%20fair%20calling%20a%20function%20twice%20%28in%20this%20case%20getInetAddress%29%20isn%27t%20really%20best%20practice%20but%20it%27s%20cheap%20enough%20that%20it%27s%20probably%20not%20worth%20worrying%20about.%5Cr%5Cn%5Cr%5CnOh%20and%20I%20would%20suggest%20renaming%20the%20function%20as%20GetLocalHostAddressAsString.%22%2C%20%22created_at%22%3A%20%222015-08-19T22%3A56%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A34%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL170-262%22%7D%2C%20%22Pull%204ad4e709a8fb1ed9fce29ac6135b57a16b488c6f%20thali/thalireplicationmanager.js%2096%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37127746%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20multiple%20calls%20to%20restartMuxServerBridge%20here%20and%20in%20two%20more%20places%20below%20make%20me%20really%20nervous.%20It%20is%20at%20least%20theoretically%20possible%20for%20say%20both%20the%20incomingClientsocket%20and%20the%20server%20to%20error%20out%20at%20the%20same%20time.%20In%20that%20case%20we%20could%20end%20up%20calling%20restartMuxServerBridge%20multiple%20times.%20This%20would%20seem%20bad%20as%20we%20would%20try%20to%20stop%20and%20start%20things%20multiple%20times.%20Shouldn%27t%20we%20be%20protecting%20against%20multiple%20calls%20to%20restartMuxServerBridge%3F%20Or%2C%20more%20to%20the%20point%2C%20shouldn%27t%20subsequent%20calls%20when%20we%20already%20have%20one%20restart%20in%20progress%20be%20treated%20as%20thunks%3F%22%2C%20%22created_at%22%3A%20%222015-08-14T23%3A14%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20with%20a%20flag%20to%20determine%20whether%20the%20cleanup%20has%20been%20called%20before%20so%20it%20can%20only%20be%20called%20once.%22%2C%20%22created_at%22%3A%20%222015-08-18T18%3A57%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578097%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mpodwysocki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A06%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20thali/thalireplicationmanager.js%3AL202-264%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37360169%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20Line%20271%20below%20is%20not%20thread%20safe%20because%20between%20the%20null%20check%20on%20271%20and%20the%20stop%20on%20272%20someone%20else%20could%20have%20changed%20mBtToRequestSocket%20to%20be%20null.%20Please%20first%20copy%20to%20a%20local%20variable%20and%20then%20check%20for%20null%20and%20call%20stop.%22%2C%20%22created_at%22%3A%20%222015-08-18T22%3A10%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A14%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL241-262%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20271%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37447766%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22See%20my%20previous%20comment%20regarding%20why%20it%27s%20never%20safe%20to%20iterate%20on%20a%20concurrent%20object%20like%20this.%22%2C%20%22created_at%22%3A%20%222015-08-19T18%3A11%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A00%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL155-296%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%2041%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37354248%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20Why%20is%20this%20method%20synchronized%3F%20At%20worst%20it%20can%20return%20an%20outdated%20response%20but%20that%20is%20always%20possible.%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A12%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T22%3A48%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL55-75%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtToRequestSocket.java%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37478904%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20Can%20you%20please%20upgrade%20this%20file%20along%20the%20lines%20that%20we%20discussed%3F%20For%20example%2C%20in%20run%28%29%20you%20have%20this%20enormous%20if%20statement%20if%20srvSocket%20%21%3D%20null%20and%20then%20a%20tiny%20statement%20at%20the%20bottom%20if%20it%20is%20null.%20In%20truth%20that%20error%20case%20should%20be%20right%20after%20line%2082%20inside%20the%20catch%20statement%20followed%20by%20a%20return%20to%20exit.%22%2C%20%22created_at%22%3A%20%222015-08-19T22%3A56%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22changed%22%2C%20%22created_at%22%3A%20%222015-08-24T07%3A22%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20I%27ll%20add%20specific%20comments%20instead.%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A32%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL170-262%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/StreamCopyingThread.java%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37813839%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22callback%2C%20mInputStream%20and%20mOutputStream%20can%20all%20be%20final.%22%2C%20%22created_at%22%3A%20%222015-08-24T22%3A40%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22with%20current%20re-structuring%2C%20the%20IDE%20gives%20error%20if%20I%20try%20setting%20them%20final%2C%20thus%20not%20attempting%20to%20change.%22%2C%20%22created_at%22%3A%20%222015-08-25T08%3A04%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-25T19%3A07%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/StreamCopyingThread.java%3AL8-26%22%7D%2C%20%22Pull%20879fea0fb3d79df0585b6ba4674b1f0f52c2f133%20src/android/java/io/jxcore/node/JXcoreExtension.java%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37841740%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ok%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-25T08%3A02%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5235141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DrJukka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-25T19%3A07%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/JXcoreExtension.java%3AL4-34%22%7D%2C%20%22Pull%206d929e4c702ac4914b30b94f77618ea4d6083ab5%20src/android/java/io/jxcore/node/BtConnectorHelper.java%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37354529%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40DrJukka%20Why%20isn%27t%20this%20synchronized%3F%20You%20can%20still%20have%20a%20race%20condition%20where%20the%20same%20mBTConnector%20has%20its%20stop%20method%20called%20twice.%20Does%20that%20not%20matter%3F%22%2C%20%22created_at%22%3A%20%222015-08-18T21%3A15%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A00%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL76-94%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtConnectorHelper.java%20230%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37447443%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20this%20literally%20never%20happen%20and%20therefore%20should%20cause%20an%20exception%20to%20be%20thrown%3F%22%2C%20%22created_at%22%3A%20%222015-08-19T18%3A08%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T18%3A58%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtConnectorHelper.java%3AL155-296%22%7D%2C%20%22Pull%2002ec9ff3aa6e94ff206c2e0175e9061467be1512%20src/android/java/io/jxcore/node/BtToRequestSocket.java%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/thaliproject/Thali_CordovaPlugin/pull/69%23discussion_r37460113%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20generally%20considered%20best%20practice%20to%20return%20NULL%20when%20you%20don%27t%20have%20a%20valid%20response.%20Empty%20string%20is%20ambiguous%20since%20it%20could%20just%20be%20that%20the%20string%20is%20supposed%20to%20be%20empty%20as%20opposed%20to%20%5C%22I%20can%27t%20get%20the%20address%5C%22%20which%20is%20NULL%20%28or%20if%20that%20isn%27t%20supposed%20to%20happen%2C%20an%20exception%29.%5Cr%5Cn%5Cr%5CnAlso%2C%20can%27t%20this%20method%20be%20private%3F%20Nobody%20calls%20it%20outside%20of%20this%20function.%22%2C%20%22created_at%22%3A%20%222015-08-19T19%3A56%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-24T19%3A02%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1480964%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yaronyg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/android/java/io/jxcore/node/BtToRequestSocket.java%3AL170-262%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 303ae2ac9921143683c569d7046cd50f0da23b12 thali/thalireplicationmanager.js 36'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r36887935'>File: thali/thalireplicationmanager.js:L166-185</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> What if we didn't get an error on the disconnect? In that case won't err be null? Shouldn't we check for that and only run line 169 and 170 if there is an actual error?
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> Fixed as per latest commit
- [x] <a href='#crh-comment-Pull 303ae2ac9921143683c569d7046cd50f0da23b12 thali/thalireplicationmanager.js 62'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r36888127'>File: thali/thalireplicationmanager.js:L202-246</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> /sockiet/socket/
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> Fixed
- [x] <a href='#crh-comment-Pull 303ae2ac9921143683c569d7046cd50f0da23b12 thali/thalireplicationmanager.js 58'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r36888210'>File: thali/thalireplicationmanager.js:L202-246</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> If we got an end event doesn't that mean the socket is already destroyed? Any danger from destroying a socket twice?
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> I haven't noticed any exceptions being thrown from this code, so I'm not sure
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Why not just write a quick test to be sure? E.g. open a socket, destroy it and then destroy it again. It's best to be sure.
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: Per our conversation
- [x] <a href='#crh-comment-Pull 303ae2ac9921143683c569d7046cd50f0da23b12 thali/thalireplicationmanager.js 70'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r36888421'>File: thali/thalireplicationmanager.js:L202-246</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Why do you destroy the incomingClientSocket on error but not on end?  Of course given my previous question about destroying "end"ed sockets maybe this is correct and line 207 is the problem?
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> I'm on the assumption that end is perfectly normal but error is not.  Pretty sure we can get rid of that code for destroying the socket because an error should do that already.  However, on stream error we might want to tear down the incoming client socket
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: Please tell me there are tests to be sure you are right?
- [x] <a href='#crh-comment-Pull 303ae2ac9921143683c569d7046cd50f0da23b12 thali/thalireplicationmanager.js 74'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r36889852'>File: thali/thalireplicationmanager.js:L202-246</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> /sockiet/socket/
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> Fixed
- [x] <a href='#crh-comment-Pull c10d2e6341ce7528d45b8d1c82c423e712987b9c thali/thalireplicationmanager.js 72'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37000558'>File: thali/thalireplicationmanager.js:L206-250</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> If we get an error on the stream don't we need to shut down the clientSocket?
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> Fixed as per suggestion
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> I'm confused. Now we don't seem to be tracking any errors what so ever on stream. That doesn't sound right.
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> I've removed the stream error handling because if that really goes bad then we've got larger problems on our hand.  And no, we don't want to tear that down else we get errors.
- [x] <a href='#crh-comment-Pull c10d2e6341ce7528d45b8d1c82c423e712987b9c thali/thalireplicationmanager.js 77'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37000591'>File: thali/thalireplicationmanager.js:L206-250</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> If we got an error on the clientSocket then hasn't it already destroyed itself?
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> Destroying a socket is idempotent or at least should be according to my tests
- [x] <a href='#crh-comment-Pull 4ad4e709a8fb1ed9fce29ac6135b57a16b488c6f thali/thalireplicationmanager.js 73'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37127600'>File: thali/thalireplicationmanager.js:L202-264</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Shouldn't this be before line 206? I realize that given the single threaded nature of Javascript it shouldn't theoretically be possible for the event to be emitted before the handler is registered but boy do I hate tempting the gods.
Also shouldn't this be once not on? Otherwise won't this will get called on EVERY stopped event which means that theoretically it isn't possible to ever stop the replication manager?
Oh and what happens if we get a STOP_ERROR? Should we really not try to start again?
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> Fixed as per suggestion
- [x] <a href='#crh-comment-Pull 4ad4e709a8fb1ed9fce29ac6135b57a16b488c6f thali/thalireplicationmanager.js 96'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37127746'>File: thali/thalireplicationmanager.js:L202-264</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> These multiple calls to restartMuxServerBridge here and in two more places below make me really nervous. It is at least theoretically possible for say both the incomingClientsocket and the server to error out at the same time. In that case we could end up calling restartMuxServerBridge multiple times. This would seem bad as we would try to stop and start things multiple times. Shouldn't we be protecting against multiple calls to restartMuxServerBridge? Or, more to the point, shouldn't subsequent calls when we already have one restart in progress be treated as thunks?
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> Fixed with a flag to determine whether the cleanup has been called before so it can only be called once.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 31'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37353843'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L55-75</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> I am very concerned that the approach of wrapping lastAvailableList in a synchronized is too error prone. If someone, somewhere ever forgets to protect lastAvailableList it all goes bad. Please replace this use of synchronized and make lastAvailableList into a CopyOnWriteArrayList or equivalent. The overhead of copying the array's contents shouldn't matter given the physical limitations on how many devices we can potentially discover.
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Just adding your tag sign so you get notified since this comment is in your code.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 41'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37354248'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L55-75</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Why is this method synchronized? At worst it can return an outdated response but that is always possible.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 48'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37354529'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L76-94</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Why isn't this synchronized? You can still have a race condition where the same mBTConnector has its stop method called twice. Does that not matter?
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 26'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37355139'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L55-75</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Does it ever make sense for start to be called twice on the same BtConnectorHelper object? If not then I would suggest that we can get rid of synchronized and instead just use AtomicBoolean to stick in a guard and call it a day.
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1:
BTW, we really need an atomic guard here so we can prevent someone accidentally calling startBroadcast twice without waiting for the callback. We should get an error on the second startBroadcast. But we can fix this later when I add a test for it.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 88'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37355581'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L97-112</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka I don't believe this is safe. You can't synchronize on an object that can become null, I believe it will cause an exception. A much simpler approach is to just make a local copy of mBtToRequestSocket and then test if the local copy is null and issue methods based on that. This assumes, of course that all of mBtToRequestSocket's methods are thread safe but of course they should be given our asynchronous environment.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 84'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37355798'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L76-94</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka This method really confuses me. I thought that you said that BlueTooth supports connecting to multiple different devices simultaneously. But this Disconnect method seems to assume that we will only connect to a single peer at a time. What am I missing?
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: I realize this will now be fixed in 0.8
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 102'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37356404'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L97-112</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> I would suggest having a mBtToRequestSocket class that contains all the peers we are connected to and contains a method 'disconnectPeer(peerId)' that will use a concurrent safe list with an atomic update and in that atomic update you would then check to see if the peerid exists, call close on the mBtToRequestSocket and then return null for the peer ID's state. I suspect this will be the most robust implementation that doesn't require a bunch of fiddly synchronized calls.
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: To be fixed in 0.8
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 113'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37356582'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L116-139</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka As mentioned above this isn't safe. If there are any more examples of this I won't call them out. I'm going to assume that you will search for them.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 122'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37357316'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L116-139</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Instead of synchronizing on mServerSocketList we should use CopyOnWriteArrayList or equivalent.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 124'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37357377'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L116-139</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Note that when you switch to CopyOnWriteArrayList or equivalent you will want to use methods like elements() to get a consistent set of contents to iterate over.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 130'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37357503'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L116-139</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Here you will want to use remove() with the non-null tmp so you make sure you remove the right object.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 131'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37357657'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L116-139</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> I don't understand the intended semantics of 'ret'. It seems to mean "I found and closed at least one server socket". But why is that useful? I would have thought that you would only want to return true if you successfully closed all the sockets? And if there were no sockets then shouldn't you still return true since you did close all sockets, there just weren't any?
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1:
I'm going to assume this will get fixed in 0.8 since the current functionality won't work there. The return value is only used for kill connection and in 0.8 kill connection needs to be peer specific. So you will have to change this logic there.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 138'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37358143'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L116-139</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Sorry to stick this comment here but I can't add comments to GetBluetoothAddress, GetDeviceName or SetDeviceName. In both cases shouldn't the return value be null if we can't get the default adapter? Also rather than using:
```java
if (bluetooth != null) {
ret = bluetooth.getName();
}
return ret;
```
Wouldn't it be cleaner to just use:
```java
return bluetooth == null ? null : bluetooth.getName();
```
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Also sorry to stick this comment here but I'm limited by how GitHub reviews work. In any case, why is GetKeyValue and SetKeyValue still around? I thought we were going to get rid of these? Sorry if I've lost my mind on this one but I thought this was functionality we removed?
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 147'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37358447'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L194-226</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Can you please use a more descriptive name like localMBtToRequestSocket?
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 155'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37358570'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L194-226</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka This assumes that we can connect to only one peer at a time. But I thought you said that Bluetooth supports multiple simultaneous connections to different peers?
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: To be fixed in 0.8
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 156'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37358650'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L194-226</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka I would suggest that the code would be easier to read if you just stuck a return after line 204. That would allow you to get rid of the next else and indent all of that code one tab space to the left. It's easier to read code that isn't deeply nested.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 195'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37359026'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L241-262</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka This comment is in regards to line 239 above where you return "Device Address for .... not found from Discovered device list". The code, I believe, would be easier to read if you instead put in
```java
if (selectedDevice == null) {
tmpCallback.ConnectionStatusUpdate("Device Address for " + toPeerId + " not found from Discovered device list.",-1);
return;
}
```
Then you can remove the `if (selectedDevice != null)` and out indent that code.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 146'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37359460'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L194-226</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka What happens if BeginConnectPeer is called twice in parallel? This is perfectly reasonable if we are trying to connect to two different peers. I'm fairly confident that making the method synchronized is not the right solution. This, for example, won't solve what happens if someone tries to simultaneously connect and disconnect since synchronized methods apply to repeated calls to the method, not the object. I"m not worried about race conditions as much as I'm worried about us trying to connect to the same peer twice. Will Bluetooth's layer stop that? Or can you open two Bluetooth client sockets to the same device?
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: To be solved in 0.8
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 179'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37359584'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L194-226</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka I'm guessing line 225 below isn't correct since it presumes we can only connect to one peer at a time?
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1:
Will be fixed I assume in 0.8.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 187'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37359656'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L241-262</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka On line 236 above /conenctivity/connectivity/
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka On line 248 what happens if bluetoothSocket is null? Currently the code does nothing. That is fine but in that case please rewrite the code to check for null and return and then out indent the rest of the code. I'll stop making this comment about 'if' styling (e.g. don't indent things like crazy, instead use return) and assume you will check all your files for it and please fix.
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka The connected method is, I think, unnecessarily hard to read. Could you please refactor it into two methods, one called ConnectedIncoming and another called ConnectedOutgoing and whomever calls this can then switch between the two based on the incoming value? It would make the code much easier to read.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> The Connected method is re-Structured for better readability.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 src/android/java/io/jxcore/node/BtConnectorHelper.java 203'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37360169'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L241-262</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Line 271 below is not thread safe because between the null check on 271 and the stop on 272 someone else could have changed mBtToRequestSocket to be null. Please first copy to a local variable and then check for null and call stop.
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 thali/thalireplicationmanager.js 33'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37364290'>File: thali/thalireplicationmanager.js:L106-116</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Purely as an example of defensive programming would it make sense to put a return after line 114?
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> Fixed as per comment with return stop and return start
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 thali/thalireplicationmanager.js 49'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37364572'>File: thali/thalireplicationmanager.js:L117-149</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> It seems like this code is assuming that PEER_AVAILABILITY_CHANGED will always return all peers that are current visible? But in looking [here](https://github.com/thaliproject/Thali_CordovaPlugin/blob/story_0/doc/api/connectivity.md) it only says that the event will be called when a peer's availability changes. Which implies that if a peer's availability hasn't changed then it won't be included in the event. In which case we just overwrite this._peers with an incomplete list of who is available! That doesn't sound right. What am I missing?
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> Fixed as per suggestion with the following:
```js
this._peers = peers.reduce(function (acc, peer) {
acc[peer.peerIdentifier] = peer; return acc;
}, this._peers);
```
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 thali/thalireplicationmanager.js 58'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37364857'>File: thali/thalireplicationmanager.js:L117-149</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Could you please use a slightly more informative variable name than p? Like existingPeerReplication? I'm slow and keep getting confused between peer and p.
- <a href='https://github.com/mpodwysocki'><img border=0 src='https://avatars.githubusercontent.com/u/11578097?v=3' height=16 width=16'></a> changed from p to existingReplication
- [x] <a href='#crh-comment-Pull 6d929e4c702ac4914b30b94f77618ea4d6083ab5 thali/thalireplicationmanager.js 153'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37365290'>File: thali/thalireplicationmanager.js:L185-308</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Isn't this assuming that we can only be in retry with a single peer at a time? What if we have multiple peers we are simultaneously connecting to and we are in retry with one or more of them? Shouldn't isInRetry really be an array indexed by peerID?
Also while on the topic can we take clients and replications and the rest and collapse them into one array with an object? It would make it much easier to think about threading issues since all the places state can blow up are in one place?
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: I'm going to assume this will get fixed in story 0.8.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 23'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37438236'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L5-25</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> On line 28 below you set context to null. Which is fine but since context is only set in the constructor you can make it final. It's always good habit in multi-threaded code to make anything that can be final, into final, it prevents mistakes. So i would review all your state variables and see which ones you can make final.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> fixed
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 29'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37438768'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L32-44</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> You really want to make this final as well.  Life is much easier if a variable can never go null. In the case of lastAvailableList, for example, the only place you ever reset it is in AddPeerIfNotDiscovered and you can just call the clear method on the variable.
To be clear, you do NOT have a bug here. The code is correct. The use of final and clear is just meant as a defensive coding technique.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 44'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37440232'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L52-70</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Here is a fun example of why sometimes you have to use synchronized methods. Ask yourself the following question - what happens if start and stop both get called at the same time from different threads?
But here is a better question - is it possible for start and stop to be called at the same time from different threads? I don't think so. But we should be sure. Here is my reasoning - The only entity that should EVER call BtConnectorHelper is JXcoreExtension and JXcore guarantees that JXcoreExtension will always be called on the same thread (at least I think it guarantees that, we should check with Oguz). In that case methods like start and stop can only be called on a single thread since only JXcoreExtension can call them. If that is all true then this is worth some kind of comment at the top of the file pointing out that we are depending on the fact that other than in callbacks all the methods in BtConnectorHelper will only be called by JXcoreExtension and JXcoreExtension will only be called from the same thread.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 106'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37441413'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L74-151</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> The use of an empty string to mean disconnect really worries me. Mostly because this means that if someone in node.js land calls disconnect with an empty string that will also cause the current peer to disconnect. That is a great way to create really bad bugs. We should always make the programmer be explicit about their desire. So I would remove the "" flag (which anyway is ambiguous) and create a private method "DisconnectAll" that Stop can call and make Disconnect "safe" by requiring an exact peerid match.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 119'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37442588'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L74-151</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> This comment is misleading since the method is also used by stop.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 123'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37442700'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L74-151</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> If we make mServerSocketList final then it can never be null, only empty.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 137'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37443396'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L74-151</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> It is super unsafe to iterate on a thread safe object using a counter since the membership can change during the iteration. You have to model this stuff in your head. On each method call you have to ask yourself "what happens if we have multiple simultaneous calls?" If multiple people can work on mServerSocketList at the same time then certainly while we are iterating on its membership that membership can change! Also whenever using a new class you should always read its docs. The docs on CopyOnWriteArrayList (see [here](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/CopyOnWriteArrayList.html)) explicitly calls out the fact that it uses a snapshot style iterator to handle exactly this problem. So what you need to do is to call either iterator() or listIterator() in order to get a thread safe snap shot of the list's contents and iterate on that.
Also using that iterator should simplify the code below since, for example, you don't need to check for null. You should never be putting nulls into the list. Instead when you want to remove a member you should call remove. Keep in mind, btw, that you should NEVER remove by index. It's never safe. I'm shocked they even offer it as an option.
In fact, if I were you, since order doesn't matter to either lastAvailableList or mServerSocketList I would urge you to consider changing both variables to be of type CopyOnWriteArraySet. This will remove most of the really unsafe methods and make it easier to write correct code.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 220'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37444020'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L74-151</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> I'm surprised this didn't cause a compiler error. This method returns a boolean but we are returning null? Null for a primitive type? In any case shouldn't this be `return bluetooth == null ? false : bluetooth.setName(name)`?
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 172'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37444651'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L74-151</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Since this method is only used inside of BtConnectorHelper wouldn't it be easier to make this method private?
It's generally good defensive programming to make as many things private as you can. It reduces the number of places where it can cause trouble. Now, to be fair, this can be a pain when writing tests and sometimes one will either make things public or use protected for those purposes. But that doesn't apply here. So I would evaluate the methods and see what you can make private.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 60'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37444805'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L52-70</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> And yes (I just saw this in IntelliJ as well), this can be simplified to `return mBTConnector != null`
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> fixed
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37446744'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L5-25</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Please do me a favor. Follow the team read me instructions to set up ThaliTest. Then open up IntelliJ and go to file->open and point it to the build.gradle file in ThaliTest/platforms/android. Then go to Analyze->Inspect Code and choose custom scope, choose local and then select the android/src directory and hit 'Include Recursively'. You should see a pattern of the form `file[android]:src//*` then hit OK and run the analysis. Then start looking through the analysis. Not everything it calls out is relevant (for example, it catches some issues with JXcore) and not all of its suggestions are necessary but it found a bunch of really obvious errors. I would appreciate it if you could run it so that I don't have to even think about those classes of errors and can just look at the code. Thanks!
Oh, one more thing. Before you run the analysis go to file->project structure->project and set the Project SDK to Android and set the project language level to 7. This will prevent some spurious suggestions.
But please do this. It will clean up spelling errors. Inefficient Ifs. Spurious variables. Unused methods. Etc. Having all this cleaned up before a code review makes for a much more efficient code review.
But remember, suggestions aren't orders and some of their suggestions can make things worse. You have to keep your wits about you and make sure that their suggestions actually make sense given your goals for the code. This is not a mechanical exercise. Think of it rather as hints. You need to think if you agree with the hints that IntelliJ gives.
Thanks!
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 223'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37446927'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L74-151</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> It's best practice to put member variables at the top of the class definition. This lets people see at a glance all the state the class maintains.
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: Oh well, win some, lose some. :)
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 226'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37447066'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L155-296</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> This one is really optional but when I'm dealing with multi-threaded code I will tend to put a final on my method arguments (e.g. final String toPeerId) just to make sure they are immutable and I don't accidentally mess with them in the code. But this is a matter of taste.
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: BTW, you could also have put final on connectStatus.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 227'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37447168'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L155-296</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Why is this tmpCallback variable created? No one can change the pointer to connectStatusCallback from under you since it's local. And you don't use connectStatusCallback for anything but setting tmpCallback. So I'm confused why it's here.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 230'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37447443'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L155-296</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Shouldn't this literally never happen and therefore should cause an exception to be thrown?
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 264'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37447644'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L155-296</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> I'm not sure what the error should be in this case but I don't think this is it. I would expect a standard error, defined in the doc file, of the form like "Maximum peer connections reached, please try again after disconnecting a peer."
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 271'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37447766'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L155-296</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> See my previous comment regarding why it's never safe to iterate on a concurrent object like this.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtConnectorHelper.java 273'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37448144'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L155-296</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Might it make sense to make lastAvailableList into something like a ConcurrentHashMap? No need to implement your own search function. Entries could be added based on peerId.
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: I'm giving up on this for now but when I next have my hand in the code I'm fixing this! :)
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtToRequestSocket.java 8'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37460113'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L170-262</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> It's generally considered best practice to return NULL when you don't have a valid response. Empty string is ambiguous since it could just be that the string is supposed to be empty as opposed to "I can't get the address" which is NULL (or if that isn't supposed to happen, an exception).
Also, can't this method be private? Nobody calls it outside of this function.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtToRequestSocket.java 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37474148'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L170-262</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Question - why is there a setPort method? We only seem to call it in one place and we always pass 0. Wouldn't it be easier to just include the port in the constructor? Or better yet, never include a port at all and always have it be 0? If we set it in the constructor then we can make mHTTPPort final and that is always a good thing.
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka I'd like to see a response to this issue. Thanks!
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtToRequestSocket.java 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37478904'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L170-262</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka Can you please upgrade this file along the lines that we discussed? For example, in run() you have this enormous if statement if srvSocket != null and then a tiny statement at the bottom if it is null. In truth that error case should be right after line 82 inside the catch statement followed by a return to exit.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> changed
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1: I'll add specific comments instead.
- [x] <a href='#crh-comment-Pull 02ec9ff3aa6e94ff206c2e0175e9061467be1512 src/android/java/io/jxcore/node/BtToRequestSocket.java 7'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37478913'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L170-262</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> From a style perspective I would have done something like
```Java
return localHostSocket == null || localHostSocket.getInetAddress() == null ? null : localHostSocket.getInetAddress().toString();
```
Although to be fair calling a function twice (in this case getInetAddress) isn't really best practice but it's cheap enough that it's probably not worth worrying about.
Oh and I would suggest renaming the function as GetLocalHostAddressAsString.
- [x] <a href='#crh-comment-Pull 46695bbadbca984cb8cc01990db1527e9fd7c6b6 src/android/java/io/jxcore/node/BtConnectorHelper.java 186'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37685313'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L51-332</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> @DrJukka This isn't the idiomatic way of handling this. As IntelliJ will automatically fix for you this should be written as:
```Java
for (BtToServerSocket rSocket : mServerSocketList) {
...
}
```
BTW, you shouldn't need to test for null since as long as you use 'clear' you will never have a null entry. If you are testing for null it should be for defensive purposes but in that case you should throw an exception or at least log something if you find a null since that would be an error.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> changed it to be implemented as suggested by IntelliJ
- [x] <a href='#crh-comment-Pull 46695bbadbca984cb8cc01990db1527e9fd7c6b6 src/android/java/io/jxcore/node/BtConnectorHelper.java 327'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37686263'>File: src/android/java/io/jxcore/node/BtConnectorHelper.java:L51-332</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> This whole section from 178 to 188 should be replaced with a switch statement. This is literally what they were invented for.
```Java
switch (tmpConn.TryConnect(selectedDevice)) {
case Connecting:
mConnectStatusCallback = connectStatusCallback;
break;
etc.
default: throw new RuntimeException("Unrecognized enum type!");
}
```
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> done
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/BtToRequestSocket.java 8'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37795455'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L1-7</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> mmSocket and readyCallback should both be final.
Also mStopped is set in lots of places but is never actually checked. What purpose does it serve?
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/BtToRequestSocket.java 37'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37795976'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L38-45</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Below you try to get mmSocket.getInputStream and getOutputStream. If they fail then an exception is thrown.
First, it is an extremely bad idea to ever catch Exception directly. This hides lots of bad things. See [here](http://www.javaworld.com/article/2073800/testing-debugging/beware-the-dangers-of-generic-exceptions.html) for why this is a bad idea. Please replace the catch with the specific Exception(s) being thrown.
Second, why are we allowing the object to continue happily on its way when two key structures can't be retrieved? The object needs to go into some bad state. I'd actually argue that the right thing to do is to just throw the exception and let Connected in BtConnectorHelper handle it.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> I don't see the point you are expressing. Each catch is calling Disconnected(), which will clean up the class instance in BtConnectorHelper side. Also right after calling Disconnected there is return; which stops the execution of run.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> Ok, now I understood that its was not the run, but the constructor you were referring to. I moved the code to Run, as I think I did with the BtToServerSocket already earlier.
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/BtToRequestSocket.java 50'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37796358'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L63-127</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> You already set this in the constructor. Why set it again here? You already know it's zero.
Also, how do you protect yourself against Run being called twice? I would just have a 'running' boolean (note the primitive type, not the class Boolean) marked as volatile.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> removed the variable.
I would assume that the Java-Thread itself, can not be started twice: http://stackoverflow.com/questions/1215548/is-it-legal-to-call-the-start-method-twice-on-the-same-thread
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1:
Yup, the comment on run was my bad. I was thinking of start which we use in other places. Sorry.
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/BtToRequestSocket.java 54'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37797058'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L63-127</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Per my previous comment please don't ever catch Exception directly. Also we shouldn't just quietly fail. Instead we should throw.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> lets have a chat on this. Basically its not quietly failing. Its catching an Exception and reporting it (which is causing cleanup) and then stopping.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> after re-structuring its now throwing exception
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> :+1:
I'm closing this comment because I opened a separate one where I call out the reasons why I believe that even the new Exception code is unfortunately not quite right.
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/BtToRequestSocket.java 152'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37797327'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L63-127</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> In line 148 below where you have the else in StreamCopyError shouldn't it also call mHandler.Disconnected? It seems like Disconnected is your flag that something awful has happened and getting called on StreamCopyError with an unknown thread would seem to qualify as horrible.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> Sure I add it there, would though suppose that this should not be called. Though, current code should actually work also without stopping the SendingThread in that callback (and just handling it in a stop), then I suppose the third option would never be called.
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/BtToRequestSocket.java 158'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37797557'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L150-239</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Per my previous suggestion I would actually get rid of mHTTPPort all together and just use GetLocalHostPort directly for everything and have it call the srvSocket and get the port directly.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> done
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/BtToRequestSocket.java 173'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37797690'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L150-239</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Shouldn't you mark this as volatile and check it before stop and run? In other words if this is true when stop is called then clearly stop has been called twice. Similarly if this is true when start is called then start is being called after stop. Just make sure that member variable is volatile or you can end up with some odd race conditions.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> I did mark it as volatile. Basically Stop can be called multiple times, and there is no problem calling it before start(). The run() is called by the API. And supposedly  the API is designed in a way that it will only be called once.
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Fair point on run. But in that case, what purpose is mStopped? It gets set but near as I can tell it literally never gets checked. So why not just remove it?
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/BtToServerSocket.java 2'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37811334'>File: src/android/java/io/jxcore/node/BtToServerSocket.java:L13-52</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> A lot of my comments from BtToRequestSocket apply here since the code is so similar. This includes everything from never catching the Exception object to guarding start and stop via mStopped to making mHTTPPort into an accessor method to making sure we properly re-throw exceptions rather than silently swallow them, etc.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> For catch- lets chat, and I'll fix things if needed really quickly after the chat. For mHTTPPort, in this case we are actually getting port externally set, so we need to use variable in here.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> Did actually move the stuff back to constructor, also made it throwing the Exception. Needed this when I got to the restructuring phase, the throwing code is now in base class.
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/BtToServerSocket.java 133'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37811724'>File: src/android/java/io/jxcore/node/BtToServerSocket.java:L59-109</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> StreamCopyError in this file is literally line for line identical can you please factor it out into some common class? We don't want to repeat code. It just invites bugs. In fact large parts of BtToRequestSocket and BtToServerSocket are identical include StreamCopyError, big chunks of run(), GetLocalHostPort, GetLocalHostAddressAsString, Stop(), SetIdAddressAndName, GetPeerId, GetPeerName, GetPeerAddress and print_Debug. Can you please factor all these methods out into a common base class and inherit from there?
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> Done.
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/ConnectivityMonitor.java 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37811995'>File: src/android/java/io/jxcore/node/ConnectivityMonitor.java:L8-60</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> I can't find any references anywhere in the code that call this class. Unless we are calling this by reflection it is not being used. In that case can we remove it and its reference in plugin.xml?
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> The implementation was requested a while back, and thus is implemented. Supposing that its not really used. Also the life cycle monitoring code is supposedly currently not used at all. If indeed we decide that these are not needed, we could then remove them from the plugin.
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/JXcoreExtension.java 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37812889'>File: src/android/java/io/jxcore/node/JXcoreExtension.java:L4-34</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> This file could really use some re-factoring when it comes to if statements. There are several examples where you have big if statements followed by a tiny else (usually an error). Just checking for the error upfront and then de-indenting the main if would make for more readable code.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> done
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/JXcoreExtension.java 46'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37813112'>File: src/android/java/io/jxcore/node/JXcoreExtension.java:L4-34</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> In METHODSTRING_STARTBROADCAST if the wrong number of arguments are passed in then the function will silently fail and never return an error. Please fix.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> changed
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/StreamCopyingThread.java 30'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37813839'>File: src/android/java/io/jxcore/node/StreamCopyingThread.java:L8-26</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> callback, mInputStream and mOutputStream can all be final.
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> with current re-structuring, the IDE gives error if I try setting them final, thus not attempting to change.
- [x] <a href='#crh-comment-Pull 879fea0fb3d79df0585b6ba4674b1f0f52c2f133 src/android/java/io/jxcore/node/JXcoreExtension.java 47'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37841740'>File: src/android/java/io/jxcore/node/JXcoreExtension.java:L4-34</a></b>
- <a href='https://github.com/DrJukka'><img border=0 src='https://avatars.githubusercontent.com/u/5235141?v=3' height=16 width=16'></a> ok
- [x] <a href='#crh-comment-Pull 14da11066eef648c3c4e4e46b6ef938a1a2d5378 src/android/java/io/jxcore/node/BtToRequestSocket.java 89'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37899296'>File: src/android/java/io/jxcore/node/BtToRequestSocket.java:L11-103</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> We must not ever catch Exception. This is pretty much always wrong (in the same sense that using GOTOs is always wrong, except, in the few cases where it isn't and this isn't one of them). In this case the obvious problem is that run is on its own thread so any exceptions will be eaten by the thread if they aren't caught.
Except Java has a specific feature to handle this, UncaughtExceptionHandler. This is a method on all Thread objects that lets you register a handler who will be called if the thread exits with an exception. That handler should then repeat the exception on the main thread. Yes, there are other mechanisms like the default unhandled exception handler but it's better hygiene to set handlers as low in the chain as possible.
The idea is that this catch should only catch exceptions we are expecting, like ioExceptions. But by catching the root Exception object we also catch errors that are deadly serious and we must not catch, like RuntimeException and all of its children that include fun things like null pointer exceptions and indexing errors. The kind of exceptions that need to cause the program to fail because something has gone horribly wrong.
So please, use UncaughtExceptionHandler on all of your thread objects in all of your classes and use a generic handler that just re-throws anything it gets onto the main thread. And please only catch here specific exceptions you should be looking for like ioExceptions.
- [x] <a href='#crh-comment-Pull 14da11066eef648c3c4e4e46b6ef938a1a2d5378 src/android/java/io/jxcore/node/BtToSocketBase.java 144'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#discussion_r37901398'>File: src/android/java/io/jxcore/node/BtToSocketBase.java:L1-148</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> I don't understand why this function exists. Why can't we just use Log.i everywhere?
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69#issuecomment-135132763'>General Comment</a></b>
- <a href='https://github.com/yaronyg'><img border=0 src='https://avatars.githubusercontent.com/u/1480964?v=3' height=16 width=16'></a> Review status: 0 of 13 files reviewed at latest revision, 1 unresolved discussion, all commit checks successful.
---
<sup>**[src/android/java/io/jxcore/node/BtConnectorHelper.java, line 12 \[r1\]](https://reviewable.io:443/reviews/thaliproject/thali_cordovaplugin/69#-JxfGzz5gZRuseGY_pXs)** ([raw file](https://github.com/thaliproject/thali_cordovaplugin/blob/bdce7ef4f9230903ffc0a690180ccd4b7239d2f0/src/android/java/io/jxcore/node/BtConnectorHelper.java#L12)):</sup>
This is a comment. Please ignore it. I'm testing reviewable.io.
---
Comments from the [review on Reviewable.io](https://reviewable.io:443/reviews/thaliproject/thali_cordovaplugin/69)
<!-- Sent from Reviewable.io -->


<a href='https://www.codereviewhub.com/thaliproject/Thali_CordovaPlugin/pull/69?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/thaliproject/Thali_CordovaPlugin/pull/69?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/thaliproject/Thali_CordovaPlugin/pull/69'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/69)
<!-- Reviewable:end -->
***
***
***
***
***
***
***
***
***
***