### PR TITLE
Don't exit the Cordova process in a hook.

### DIFF
--- a/scripts/androidAfterPrepare.js
+++ b/scripts/androidAfterPrepare.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Promise = require('lie');
 var fs = require('fs-extra-promise');
 var path = require('path');
 
@@ -41,16 +40,12 @@ function replaceJXCoreExtension(appRoot) {
 
 function removeInstallFromPlatform(appRoot) {
     var installDir = path.join(appRoot, "platforms/android/assets/www/jxcore/node_modules/thali/install");
-    return fs.removeAsync(installDir);
+    fs.remove(installDir);
 }
 
-var appRoot = path.join(__dirname, "../../..");
-updateAndroidSDKVersion(appRoot);
-replaceJXCoreExtension(appRoot);
-removeInstallFromPlatform(appRoot)
-.then(function() {
-    process.exit(0);
-}).catch(function(err) {
-    console.log("Android build failed with: " + err);
-    process.exit(1);
-});   
+module.exports = function (context) {
+    var appRoot = context.opts.projectRoot;
+    updateAndroidSDKVersion(appRoot);
+    replaceJXCoreExtension(appRoot);
+    removeInstallFromPlatform(appRoot);
+};

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,9 +3,8 @@
   "version": "0.0.1",
   "description": "Just used for cordova scripts",
   "main": "",
-    "dependencies": {
-    "lie": "^2.9.1",
-    "fs-extra-promise":"^0.2.0"
+  "dependencies": {
+    "fs-extra-promise": "^0.2.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
The Android hook had an async step after which the process was exited. This
caused the Cordova process to exit too soon and was seen, for example, when
`cordova run android` was tried to be executed.

The `appRoot` variable is taken from the Cordova context instead of from
`__dirname` so that the path gets right even if the plugin is added via a
symbolic link.

Also removed unneeded dependency to the `lie` module.

Fixes #143.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/163)
<!-- Reviewable:end -->
