### PR TITLE
Disabling building iOS

### DIFF
--- a/thali/install/setUpTests.sh
+++ b/thali/install/setUpTests.sh
@@ -18,5 +18,5 @@ jx npm install --autoremove "*.gz,*.pem"
 find . -name "*.gz" -delete
 cp $1 app.js
 cordova build android --release --device
-cordova build ios --device
+# cordova build ios --device
 echo "Remember to start the test coordination server by running jx index.js"


### PR DESCRIPTION
Stopping the iOS build so tests will run much faster and we can focus on first getting iOS working

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/184)
<!-- Reviewable:end -->
