### PR TITLE
Exit the setup scripts if any sub-command fails.

### DIFF
--- a/thali/install/setUpDesktop.sh
+++ b/thali/install/setUpDesktop.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
 cd ..
 jx npm install
 jx npm link

--- a/thali/install/setUpTests.sh
+++ b/thali/install/setUpTests.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
 # The first argument must be the name of the test file to make into the app.js
 # The second argument is optional and specifies a string with an IP address to manually set the coordination server's
 # address to.
@@ -19,7 +23,7 @@ jx npm install --autoremove "*.gz,*.pem"
 # In theory we don't need the line below because we use autoremove but for some reason autoremove doesn't
 # seem to work in this case.
 find . -name "*.gz" -delete
-cp $1 app.js
+cp -v $1 app.js
 cordova build android --release --device
 # cordova build ios --device
 echo "Remember to start the test coordination server by running jx index.js"

--- a/thali/installCordovaPlugin.js
+++ b/thali/installCordovaPlugin.js
@@ -12,6 +12,9 @@ if (path.basename(rootDirectory) == "Thali_CordovaPlugin") {
 
 var installDirectory = path.join(__dirname, 'install');
 exec('jx npm install --autoremove "*.gz"', { cwd: installDirectory}, function(error, stdout, stderr) {
+   // Log the installation output for easier debugging
+   console.log(stdout);
+
    if (error) {
        console.log("Could not install dependencies for install directory. - " + error);
        process.exit(1);


### PR DESCRIPTION
The biggest reason for doing this is that these scripts are called during the
CI build process and if the scripts don't overall exit with a non-zero exit
code, the CI thinks the build worked. The result was that even when parts of
the setup failed, the CI thought the build was successful.

Cordova plugin installation output is now logged for easier debugging.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/188)
<!-- Reviewable:end -->
