### PR TITLE
Use OS temporary folder as the download cache.

### DIFF
--- a/thali/install/install.js
+++ b/thali/install/install.js
@@ -200,6 +200,78 @@ function copyDevelopmentThaliCordovaPluginToProject(appRootDirectory, thaliDontC
   });
 }
 
+/**
+ * Functionality for handling the remote cache operations.
+ */
+(function () {
+  // Will be set later on based on determining if remote cache is needed,
+  // but can be used for testing purposes to force-enable remote cache.
+  var remoteCacheEnabled = false;
+  var remoteCacheUser = 'pi';
+  var remoteCacheHost = '192.168.1.150';
+  var remoteCacheRoot = '~';
+  var remoteCacheShouldUpdate = false;
+
+  module.remoteCacheGet = function (jxCorePluginId, jxCoreVersionNumber, jxCoreCacheFolder) {
+    return new Promise(function(resolve, reject) {
+      // A hack way to determine if we are running in CI environment where
+      // we want to leverage the remote cache.
+      exec('CIGIVEMEMYIP.sh', function (err, stdout, stderr) {
+        if (err && !remoteCacheEnabled) {
+          // We are not in CI so carry on.
+          resolve();
+          return;
+        }
+        // We are in CI so add flag to enable remote cache.
+        remoteCacheEnabled = true;
+        fs.mkdirsSync(jxCoreCacheFolder);
+        console.log('We are in CI so trying to fetch the plugin via scp');
+        scp.get({
+          file: path.join(remoteCacheRoot, 'thali', 'jxcore', jxCoreVersionNumber, jxCorePluginId),
+          user: remoteCacheUser,
+          host: remoteCacheHost,
+          path: jxCoreCacheFolder
+        }, function (err, stdout, stderr) {
+          if (err) {
+            console.log('We were not able to fetch the plugin via scp');
+            // If the plugin wasn't found from the remote cache, update a flag
+            // to state that the cache should be updated after a successful download.
+            remoteCacheShouldUpdate = true;
+          } else {
+            console.log('We fetched the plugin via scp');
+          }
+          resolve();
+        });
+      });
+    });
+  };
+
+  module.remoteCacheSet = function (jxCoreCacheRoot) {
+    return new Promise(function(resolve, reject) {
+      if (remoteCacheEnabled && remoteCacheShouldUpdate) {
+        console.log('Starting to update the remote cache');
+        scp.send({
+          file: path.join(jxCoreCacheRoot, 'thali'),
+          user: remoteCacheUser,
+          host: remoteCacheHost,
+          path: remoteCacheRoot
+        }, function (err, stdout, stderr) {
+          if (err) {
+            console.log('We tried to update the remove cache, but failed');
+          } else {
+            console.log('Successfully updated the remote cache');
+          }
+          resolve();
+        });
+      } else {
+        // If we don't have to deal with the remote cache, just move on.
+        resolve();
+        return;
+      }
+    });
+  };
+}());
+
 function doesMagicDirectoryNamedExist(thaliDontCheckIn) {
   var magicFileLocation = path.join(thaliDontCheckIn, MAGIC_DIRECTORY_NAME_FOR_LOCAL_DEPLOYMENT);
   return fs.existsSync(magicFileLocation);
@@ -208,18 +280,10 @@ function doesMagicDirectoryNamedExist(thaliDontCheckIn) {
 function fetchAndInstallJxCoreCordovaPlugin(baseDir, jxCoreVersionNumber) {
   var jxCorePluginId = 'io.jxcore.node';
   var jxCorePluginFileName = 'io.jxcore.node.jx';
-  var jxCoreCacheFolder = path.join(os.tmpdir(), 'thali', 'jxcore', jxCoreVersionNumber);
+  var jxCoreCacheRoot = os.tmpdir();
+  var jxCoreCacheFolder = path.join(jxCoreCacheRoot, 'thali', 'jxcore', jxCoreVersionNumber);
   var jxCoreCachedPlugin = path.join(jxCoreCacheFolder, jxCorePluginId);
   var jxCoreFileLocation = path.join(jxCoreCacheFolder, jxCorePluginFileName);
-
-  // Will be set later on based on determining if remote cache is needed,
-  // but can be used for testing purposes to force-enable remote cache.
-  var remoteCacheEnabled = false;
-  var remoteCacheUser = 'pi';
-  var remoteCacheHost = '192.168.1.150';
-  var remoteCacheRoot = '~';
-  var remoteCacheLocation = path.join(remoteCacheRoot, 'thali', 'jxcore', jxCoreVersionNumber, jxCorePluginId);
-  var remoteCacheShouldUpdate = false;
 
   return childProcessExecPromise('cordova plugin remove ' + jxCorePluginId, baseDir)
     .then(function () {
@@ -232,37 +296,7 @@ function fetchAndInstallJxCoreCordovaPlugin(baseDir, jxCoreVersionNumber) {
       return Promise.resolve();
     })
     .then(function() {
-      return new Promise(function(resolve, reject) {
-        // A hack way to determine if we are running in CI environment where
-        // we want to leverage the remote cache.
-        exec('CIGIVEMEMYIP.sh', function (err, stdout, stderr) {
-          if (err) {
-            // We are not in CI so carry on.
-            resolve();
-          } else {
-            // We are in CI so add flag to enable remote cache.
-            remoteCacheEnabled = true;
-            fs.mkdirsSync(jxCoreCacheFolder);
-            console.log('We are in CI so trying to fetch the plugin via scp');
-            scp.get({
-              file: remoteCacheLocation,
-              user: remoteCacheUser,
-              host: remoteCacheHost,
-              path: jxCoreCacheFolder
-            }, function (err, stdout, stderr) {
-              if (err) {
-                console.log('We were not able to fetch the plugin via scp');
-                // If the plugin wasn't found from the remote cache, update a flag
-                // to state that the cache should be updated after a successful download.
-                remoteCacheShouldUpdate = true;
-              } else {
-                console.log('We fetched the plugin via scp');
-              }
-              resolve();
-            });
-          }
-        });
-      });
+      return module.remoteCacheGet(jxCorePluginId, jxCoreVersionNumber, jxCoreCacheFolder);
     })
     .then(function() {
       // Check if the plugin is found from the local cache and use that instead
@@ -330,27 +364,7 @@ function fetchAndInstallJxCoreCordovaPlugin(baseDir, jxCoreVersionNumber) {
       console.log('Adding Cordova plugin to app at: ' + baseDir);
       return childProcessExecPromise('cordova plugin add ' + cordovaPluginFolder, baseDir)
         .then(function () {
-          return new Promise(function(resolve, reject) {
-            if (remoteCacheEnabled && remoteCacheShouldUpdate) {
-              console.log('Starting to update the remote cache');
-              scp.send({
-                file: path.join(os.tmpdir(), 'thali'),
-                user: remoteCacheUser,
-                host: remoteCacheHost,
-                path: remoteCacheRoot
-              }, function (err, stdout, stderr) {
-                if (err) {
-                  console.log('We tried to update the remove cache, but failed');
-                } else {
-                  console.log('Successfully updated the remote cache');
-                }
-                resolve();
-              });
-            } else {
-              // If we don't have to deal with the remote cache, just move on.
-              resolve();
-            }
-          });
+          return module.remoteCacheSet(jxCoreCacheRoot);
         })
         .catch(function () {
           console.log('Failed to add Cordova plugin from: ' + cordovaPluginFolder);

--- a/thali/install/install.js
+++ b/thali/install/install.js
@@ -251,7 +251,7 @@ function fetchAndInstallJxCoreCordovaPlugin(baseDir, jxCoreVersionNumber) {
       }
 
       return new Promise(function(resolve, reject) {
-        var requestUrl = 'https://github.com/jxcore/jxcore-cordova-release/raw/master/' + jxCoreVersionNumber + '/io.jxcore.node.jx';
+        var requestUrl = 'http://jxcordova.cloudapp.net/' + jxCoreVersionNumber + '/io.jxcore.node.jx';
         var receivedData = 0;
         var contentLength = 0;
         var previousPercentageProgress = 0;

--- a/thali/install/install.js
+++ b/thali/install/install.js
@@ -226,7 +226,7 @@ function fetchAndInstallJxCoreCordovaPlugin(baseDir, jxCoreVersionNumber) {
       // of downloading it, if found.
       if (fs.existsSync(jxCoreCachedPlugin)) {
         console.log('Using jxcore Cordova plugin from: ' + jxCoreCachedPlugin);
-        return Promise.resolve(true);
+        return Promise.resolve();
       } else {
         fs.mkdirsSync(jxCoreCacheFolder);
       }
@@ -257,7 +257,7 @@ function fetchAndInstallJxCoreCordovaPlugin(baseDir, jxCoreVersionNumber) {
             console.log('Running jx against the file downloaded to: ' + jxCoreFileLocation);
             childProcessExecPromise('jx ' + jxCoreFileLocation, jxCoreCacheFolder)
               .then(function () {
-                resolve(true);
+                resolve();
               }).catch(function (error) {
                 console.log('Failed to process the downloaded file');
                 // Delete the "corrupted" files so that they don't interfere in subsequent
@@ -282,21 +282,17 @@ function fetchAndInstallJxCoreCordovaPlugin(baseDir, jxCoreVersionNumber) {
               });
           }));
       });
-    }).then(function(neededDownload) {
-      if (neededDownload) {
-        var cordovaPluginFolder = path.join(jxCoreCacheFolder, jxCorePluginId);
-        console.log('Adding Cordova plugin to app at: ' + baseDir);
-        return childProcessExecPromise('cordova plugin add ' + cordovaPluginFolder, baseDir)
-          .catch(function() {
-            console.log('Failed to add Cordova plugin from: ' + cordovaPluginFolder);
-            return fs.removeAsync(jxCoreCacheFolder)
-              .then(function () {
-                return Promise.reject();
-              });
-          });
-      }
-
-      return Promise.resolve();
+    }).then(function() {
+      var cordovaPluginFolder = path.join(jxCoreCacheFolder, jxCorePluginId);
+      console.log('Adding Cordova plugin to app at: ' + baseDir);
+      return childProcessExecPromise('cordova plugin add ' + cordovaPluginFolder, baseDir)
+        .catch(function() {
+          console.log('Failed to add Cordova plugin from: ' + cordovaPluginFolder);
+          return fs.removeAsync(jxCoreCacheFolder)
+            .then(function () {
+              return Promise.reject();
+            });
+        });
     });
 }
 

--- a/thali/install/package.json
+++ b/thali/install/package.json
@@ -7,6 +7,7 @@
     "fs-extra-promise": "^0.2.0",
     "lie": "^3.0.1",
     "request": "^2.64.0",
+    "scp": "^0.0.3",
     "unzip": "^0.1.11"
   },
   "scripts": {

--- a/thali/install/remote-cache.js
+++ b/thali/install/remote-cache.js
@@ -1,0 +1,92 @@
+'use strict';
+var exec = require('child_process').exec;
+var path = require('path');
+var Promise = require('lie');
+var fs = require('fs-extra-promise');
+var scp = require('scp');
+
+// Will be set later on based on determining if remote cache is needed,
+// but can be used for testing purposes to force-enable remote cache.
+var remoteCacheEnabled = false;
+var remoteCacheUser = 'pi';
+var remoteCacheHost = '192.168.1.150';
+var remoteCacheRoot = '~';
+var remoteCacheShouldUpdate = false;
+
+module.exports.get = function (localPath, remotePath) {
+  return new Promise(function(resolve, reject) {
+    // A hack way to determine if we are running in CI environment where
+    // we want to leverage the remote cache.
+    exec('CIGIVEMEMYIP.sh', function (err, stdout, stderr) {
+      if (err && !remoteCacheEnabled) {
+        // We are not in CI so carry on.
+        resolve();
+        return;
+      }
+      // We are in CI so add flag to enable remote cache.
+      remoteCacheEnabled = true;
+      fs.mkdirsSync(localPath);
+      console.log('We are in CI so trying to fetch the plugin via scp');
+      scp.get({
+        file: remotePath,
+        user: remoteCacheUser,
+        host: remoteCacheHost,
+        path: localPath
+      }, function (err, stdout, stderr) {
+        if (err) {
+          console.log('We were not able to fetch the plugin via scp');
+          // If the plugin wasn't found from the remote cache, update a flag
+          // to state that the cache should be updated after a successful download.
+          remoteCacheShouldUpdate = true;
+        } else {
+          console.log('We fetched the plugin via scp');
+        }
+        resolve();
+      });
+    });
+  });
+};
+
+module.exports.set = function (localPath, remotePath) {
+  return new Promise(function(resolve, reject) {
+    if (remoteCacheEnabled && remoteCacheShouldUpdate) {
+      console.log('Starting to update the remote cache');
+      scp.send({
+        file: localPath,
+        user: remoteCacheUser,
+        host: remoteCacheHost,
+        path: remotePath
+      }, function (err, stdout, stderr) {
+        if (err) {
+          console.log('We tried to update the remove cache, but failed');
+        } else {
+          console.log('Successfully updated the remote cache');
+        }
+        resolve();
+      });
+    } else {
+      // If we don't have to deal with the remote cache, just move on.
+      resolve();
+      return;
+    }
+  });
+};
+
+module.exports.purge = function (remotePath) {
+  return new Promise(function(resolve, reject) {
+    if (!remoteCacheEnabled) {
+      resolve();
+      return;
+    }
+    var sshConnection = 'ssh '+ remoteCacheUser + '@' + remoteCacheHost;
+    var purgeCommand = '"rm -rf ' + remotePath + '"';
+    console.log('Purging the remote cache using command: ' + purgeCommand);
+    exec(sshConnection + ' ' + purgeCommand, function (err, stdout, stderr) {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+};


### PR DESCRIPTION
A part of the installation is the download of the required version of the
JXCore Cordova plugin (currently ~90MB download) and unpacking that with jx
before adding it as Cordova plugin using Cordova commands.

This commit implements caching of the unpacked plugin folder so that the
overall installation process becomes faster. The OS temporary folder is used
for caching instead of any Thali-app folder so that full benefits of the cache
are received even if the app-folder is re-generated (this is the case with CI
scripts, for example).

This commit also adds some catches to the promise-chains so that in case of
errors, it is easier to see where the issue was.

Relates to #192.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/251)
<!-- Reviewable:end -->
