### PR TITLE
Require newer Cordova versions.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,8 @@
     <license>MIT</license>
     <keywords>cordova,jxcore,node.js,thali</keywords>
     <engines>
-        <engine name="cordova-android" version=">=3.2.0" />
+        <engine name="cordova-android" version="~4.1.0" />
+        <engine name="cordova-ios" version="~3.9.0" />
         <engine name="android-sdk" version=">=19" />
     </engines>
 


### PR DESCRIPTION
A build failure was seen with cordova-cli version < 5.3.3 so require at least
versions that were pinned in 5.3.3.

If this check fails, the fix is to upgrade Cordova on the build machine.

Fixes #350.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/363)
<!-- Reviewable:end -->


<!---
@huboard:{"order":21.2601318359375,"milestone_order":363,"custom_state":""}
-->
