### PR TITLE
Relax the installation folder requirement.

### DIFF
--- a/thali/install/install.js
+++ b/thali/install/install.js
@@ -320,20 +320,12 @@ module.exports = function(callback, appRootDirectory) {
   appRootDirectory = appRootDirectory || path.join(__dirname, '../../../../../');
   var thaliDontCheckIn = path.join(appRootDirectory, "thaliDontCheckIn" );
   var appScriptsFolder = path.join(appRootDirectory, "plugins/org.thaliproject.p2p/scripts");
-  var jxcoreFolder = path.join(appRootDirectory, 'www/jxcore' );
 
   var jxCoreVersionNumber = "0.0.8";
 
   var thaliProjectName = "thaliproject";
   var thaliDepotName = "Thali_CordovaPlugin";
   var thaliBranchName = "master";
-
-  if (!fs.existsSync(jxcoreFolder)) {
-    var jxcoreFolderNotFoundError = 'Could not locate JXCore folder. Exiting the thali plugin installation..';
-    console.log(jxcoreFolderNotFoundError);
-    callback(new Error(jxcoreFolderNotFoundError), null);
-    return;
-  }
 
   fetchAndInstallJxCoreCordovaPlugin(appRootDirectory, jxCoreVersionNumber)
     .then(function () {

--- a/thali/installCordovaPlugin.js
+++ b/thali/installCordovaPlugin.js
@@ -4,27 +4,36 @@ var path = require('path');
 
 // If we are in the test directory inside of the GitHub Repo then we are trying to do local development
 // on the desktop and don't need the Cordova dependencies
-var rootDirectory = path.join(__dirname, "../");
-if (path.basename(rootDirectory) == "Thali_CordovaPlugin") {
-    console.log("We believe we are in a clone of the GitHub Repo so we won't install Cordova dependencies");
-    process.exit(0);
+var rootDirectory = path.join(__dirname, '../');
+if (path.basename(rootDirectory) == 'Thali_CordovaPlugin') {
+  console.log('We believe we are in a clone of the GitHub Repo so we will not install Cordova dependencies');
+  process.exit(0);
 }
 
-var installDirectory = path.join(__dirname, 'install');
-exec('jx npm install --autoremove "*.gz"', { cwd: installDirectory}, function(error, stdout, stderr) {
-   if (error) {
-       // In error cases, log all possible debug output
-       console.log(stdout);
-       console.log(stderr);
-       console.log("Could not install dependencies for install directory. - " + error);
-       process.exit(1);
-   }
+// First check that the installation is done to a Cordova project
+exec('cordova info', function (error, stdout, stderr) {
+  if (error) {
+    console.log('The installation directory does not seem to be a Cordova project and currently the ' +
+                'installation is supported only to Cordova apps. Please see further information from:');
+    console.log('https://github.com/thaliproject/Thali_CordovaPlugin');
+    process.exit(1);
+  }
+  var installDirectory = path.join(__dirname, 'install');
+  exec('jx npm install --autoremove "*.gz"', { cwd: installDirectory }, function (error, stdout, stderr) {
+    if (error) {
+      // In error cases, log all possible debug output
+      console.log(stdout);
+      console.log(stderr);
+      console.log('Could not install dependencies for install directory. - ' + error);
+      process.exit(1);
+    }
 
-   require(installDirectory)(function(err, data) {
-       if (err) {
-           console.log("Failed with - " + err);
-           process.exit(1);
-       }
-       process.exit(0);
-   });
+      require(installDirectory)(function (err, data) {
+      if (err) {
+        console.log('Failed with - ' + err);
+        process.exit(1);
+      }
+      process.exit(0);
+    });
+  });
 });


### PR DESCRIPTION
Remove the check that was guarding against trying to install thali into a
non-supported folder.

This is done to allow the flexibility needed at thaliproject/postcardapp#85.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/364)
<!-- Reviewable:end -->


<!---
@huboard:{"order":21.577880859375,"milestone_order":364,"custom_state":""}
-->
