### PR TITLE
Exceptions for line length

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -14,7 +14,10 @@
     "requireDescriptionCompleteSentence": true,
     "requireReturnTypes": true
   },
-  "maximumLineLength": 80,
+  "maximumLineLength": {
+    "value": 80,
+    "allExcept": ["regex", "urlComments", "require"]
+  },
   "maximumNumberOfLines": 1000,
   "requireCamelCaseOrUpperCaseIdentifiers": true,
   "requireCapitalizedConstructors": true,


### PR DESCRIPTION
We want to exempt regex's, urls in comments and requires from the line length limit.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/368)
<!-- Reviewable:end -->
