### PR TITLE
Remove redundant rules

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,10 +1,7 @@
 {
-  "maxlen": 80,
   "esversion": 5,
-  "curly": true,
   "eqeqeq": true,
   "noarg": true,
-  "sub": true,
   "undef": true,
   "unused": "vars",
   "eqnull": true,


### PR DESCRIPTION
It's not good to have rules that do the same thing in both JSCS and JSHINT. It makes it really hard to deal with overrides and causes some weird behaviors.

I have removed maxline, curly because JSCS has much more flexible rules.

I got rid of sub because it's already been deprecated and we already have requireDotNotiation in JSCS

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/370)
<!-- Reviewable:end -->
