### PR TITLE
Use user-settable device name.

### DIFF
--- a/src/android/java/io/jxcore/node/ConnectionHelper.java
+++ b/src/android/java/io/jxcore/node/ConnectionHelper.java
@@ -187,6 +187,18 @@ public class ConnectionHelper
     }
 
     /**
+     * @return Our Bluetooth friendly name or null, if Blueooth adapter
+     * is not resolved or an error occurs while retrieving the name.
+     */
+    public String getBluetoothName() {
+        BluetoothAdapter bluetooth = BluetoothAdapter.getDefaultAdapter();
+        if (bluetooth != null) {
+            return bluetooth.getName();
+        }
+        return null;
+    }
+
+    /**
      * Checks if we have an incoming connection with a peer matching the given peer ID.
      * @param peerId The peer ID.
      * @return True, if connected. False otherwise.

--- a/src/android/java/io/jxcore/node/JXcoreExtension.java
+++ b/src/android/java/io/jxcore/node/JXcoreExtension.java
@@ -23,6 +23,7 @@ public class JXcoreExtension {
 
     public final static String METHOD_NAME_SHOW_TOAST = "ShowToast";
     public final static String METHOD_NAME_GET_BLUETOOTH_ADDRESS = "GetBluetoothAddress";
+    public final static String METHOD_NAME_GET_BLUETOOTH_NAME = "GetBluetoothName";
     public final static String METHOD_NAME_RECONNECT_WIFI_AP = "ReconnectWifiAP";
     public final static String METHOD_NAME_IS_BLE_SUPPORTED = "IsBLESupported";
 
@@ -77,6 +78,27 @@ public class JXcoreExtension {
                 //all is well, so lets return null as first argument
                 args.add(null);
                 args.add(btAddressString);
+
+                jxcore.CallJSMethod(callbackId, args.toArray());
+            }
+        });
+
+        jxcore.RegisterMethod(METHOD_NAME_GET_BLUETOOTH_NAME, new JXcoreCallback() {
+            @Override
+            public void Receiver(ArrayList<Object> params, String callbackId) {
+
+                ArrayList<Object> args = new ArrayList<Object>();
+
+                String btNameString = mConnectionHelper.getBluetoothName();
+
+                if (btNameString == null) {
+                    args.add("Unable to get the Bluetooth name");
+                    jxcore.CallJSMethod(callbackId, args.toArray());
+                    return;
+                }
+
+                args.add(null); // All is well
+                args.add(btNameString);
 
                 jxcore.CallJSMethod(callbackId, args.toArray());
             }


### PR DESCRIPTION
By using a user-settable device name, it is possible to associate device logs
better with physical devices. The problem previously was especially in cases
where a test was run simultaneously with exact same device models in which
case it wasn't straightforward to do the association.

Fixes #290.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/405)
<!-- Reviewable:end -->
