### PR TITLE
Fix an issue that prevented running two tests.

### DIFF
--- a/test/www/jxcore/perf_tests/testFindPeers.js
+++ b/test/www/jxcore/perf_tests/testFindPeers.js
@@ -16,16 +16,16 @@ var ThaliEmitter = require('thali/thaliemitter');
     }
 */
 
-function testFindPeers(jsonData, name, peerCount, addressList) {
+function testFindPeers(jsonData, name, addressList) {
     var self = this;
     this.name = name;
-    this.BluetoothAddressList = addressList;
+    this.bluetoothAddressList = addressList;
     this.commandData = jsonData;
-    this.toFindCount = peerCount;
+    this.toFindCount = addressList ? addressList.length : 0;
     this.foundPeers = {};
     this.startTime = new Date();
     this.endTime = new Date();
-    this.endReason ="";
+    this.endReason = '';
     this.emitter = new ThaliEmitter();
 
     console.log('testFindPeers created ' + jsonData);


### PR DESCRIPTION
The timeouts in the server were set in a way that a timeout from a previous
test got triggered when the next test was tried to be run and thus cut off
the execution of the second test.

This commit also fixed some log prints and the find peers test in case it
uses Bluetooth address lists.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/424)
<!-- Reviewable:end -->
