### PR TITLE
Use leveldown-mobile also on desktop.

### DIFF
--- a/test/www/jxcore/bv_tests/testThaliReplicationManager.js
+++ b/test/www/jxcore/bv_tests/testThaliReplicationManager.js
@@ -21,9 +21,7 @@ var ThaliReplicationManager = require('thali/thalireplicationmanager');
 // will not interfere with any other databases that might be created
 // during other tests.
 var dbPath = path.join(testUtils.tmpDirectory(), 'pouch-for-replication-test');
-var LevelDownPouchDB = process.platform === 'android' || process.platform === 'ios' ?
-    PouchDB.defaults({db: require('leveldown-mobile'), prefix: dbPath}) :
-    PouchDB.defaults({db: require('leveldown'), prefix: dbPath});
+var LevelDownPouchDB = PouchDB.defaults({db: require('leveldown-mobile'), prefix: dbPath});
 
 // A variable accessible from the tests and from the setup/teardown functions
 // that can be used to make sure that replication managers created during

--- a/test/www/jxcore/package.json
+++ b/test/www/jxcore/package.json
@@ -25,7 +25,6 @@
     "express-pouchdb": "^0.14.2",
     "fs-extra-promise": "^0.2.0",
     "is-property": "^1.0.2",
-    "leveldown": "^1.3.0",
     "leveldown-mobile": "^1.0.7",
     "lie": "^3.0.1",
     "minimist": "^1.2.0",

--- a/thali/install/setUpDesktop.sh
+++ b/thali/install/setUpDesktop.sh
@@ -14,4 +14,4 @@ cd install
 jx npm install
 cd ../../test/www/jxcore
 jx npm link thali
-jx npm install
+jx npm install --no-optional

--- a/thali/install/setUpTests.sh
+++ b/thali/install/setUpTests.sh
@@ -26,6 +26,10 @@ cordova create ThaliTest com.test.thalitest ThaliTest
 mkdir -p ThaliTest/thaliDontCheckIn/localdev
 
 if [ $runningInMinGw == true ]; then
+    # The thali package might be installed as link and there will
+    # be troubles later on if this link is tried to be copied so
+    # remove it here.
+    rm -rf $repositoryRoot/test/www/jxcore/node_modules/thali
     cp -R $repositoryRoot/test/www/ ThaliTest/
 else
     cp -R $repositoryRoot/test/www/ ThaliTest/www
@@ -49,19 +53,14 @@ fi
 # SuperTest which is used by some of the BVTs include a PEM file (for private
 # keys) that makes Android unhappy so we remove it below in addition to the gz
 # files.
-jx npm install --autoremove "*.gz,*.pem"
+jx npm install --no-optional --autoremove "*.gz,*.pem"
 
 # In case autoremove fails to delete the files, delete them explicitly.
-# However, 'find' command on MinGW is likely to consider the predicate '-delete'
-# invalid. In addition, in Windows file system the ThaliTest paths are usually
-# too long and if rm fails, it will abort the script. Thus, on Windows we have
-# to rely on autoremove to work. 
-if [ $runningInMinGw == false ]; then
-    find . -name "*.gz" -delete
-    find . -name "*.pem" -delete
-fi
+find . -name "*.gz" -delete
+find . -name "*.pem" -delete
 
 cp -v $1 app.js
+
 cordova build android --release --device
 
 if [ $runningInMinGw == false ]; then


### PR DESCRIPTION
The leveldown-mobile package is used in the primary target environment
(mobile devices) so it makes sense to do desktop testing also with that.

This also reduces the dependencies we have for the test apps.

Includes also changes to fix the build on Windows.

Fixes #422 and #394.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/502)
<!-- Reviewable:end -->
