### PR TITLE
Avoid writes to stderr during test run

### DIFF
--- a/test/www/jxcore/lib/testUtils.js
+++ b/test/www/jxcore/lib/testUtils.js
@@ -140,14 +140,16 @@ if (typeof jxcore !== 'undefined' && jxcore.utils.OSInfo().isAndroid) {
 }
 
 
+// Use a folder specific to this test so that the database content
+// will not interfere with any other databases that might be created
+// during other tests.
+var dbPath = path.join(module.exports.tmpDirectory(), 'pouchdb-test-directory');
+var LevelDownPouchDB = PouchDB.defaults({
+  db: require('leveldown-mobile'),
+  prefix: dbPath
+});
+
 module.exports.getTestPouchDBInstance = function (name) {
-  // Use a folder specific to this test so that the database content
-  // will not interfere with any other databases that might be created
-  // during other tests.
-  var dbPath = path.join(module.exports.tmpDirectory(),
-    'pouchdb-test-directory');
-  var LevelDownPouchDB =
-    PouchDB.defaults({db: require('leveldown-mobile'), prefix: dbPath});
   return new LevelDownPouchDB(name);
 };
 

--- a/thali/NextGeneration/thaliWifiInfrastructure.js
+++ b/thali/NextGeneration/thaliWifiInfrastructure.js
@@ -525,11 +525,11 @@ function () {
       try {
         self.expressApp.use('/', self.router);
       } catch (error) {
-        logger.error('Unable to use the given router: %s', error.toString());
+        logger.warn('Unable to use the given router: %s', error.toString());
         return reject(new Error('Bad Router'));
       }
       var startErrorListener = function (error) {
-        logger.error('Router server emitted an error: %s', error.toString());
+        logger.warn('Router server emitted an error: %s', error.toString());
         self.routerServer.removeListener('error', startErrorListener);
         self.routerServer = null;
         reject(new Error('Unspecified Error with Radio infrastructure'));
@@ -540,7 +540,7 @@ function () {
         // specify a custom error that the upper layers should listen to.
         // If this error is seen in real scenario, a proper error handling
         // should be specified and implemented.
-        logger.error('Router server emitted an error: %s', error.toString());
+        logger.warn('Router server emitted an error: %s', error.toString());
       };
       var listeningHandler = function () {
         self.routerServerPort = self.routerServer.address().port;


### PR DESCRIPTION
This commit was done so that in a success test run, we would not write to
stderr, because in some environments, such output is considered an error
behavior and fails the test.

The PouchDB.defaults call was moved so that it gets called only once, because
otherwise, event emitters gets subscribed to many time which caused a warning
like `EventEmitter memory leak detected` that was written to stderr.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/557)
<!-- Reviewable:end -->
