### PR TITLE
Avoid memory leak warnings

### DIFF
--- a/test/www/jxcore/lib/testUtils.js
+++ b/test/www/jxcore/lib/testUtils.js
@@ -140,14 +140,16 @@ if (typeof jxcore !== 'undefined' && jxcore.utils.OSInfo().isAndroid) {
 }
 
 
+// Use a folder specific to this test so that the database content
+// will not interfere with any other databases that might be created
+// during other tests.
+var dbPath = path.join(module.exports.tmpDirectory(), 'pouchdb-test-directory');
+var LevelDownPouchDB = PouchDB.defaults({
+  db: require('leveldown-mobile'),
+  prefix: dbPath
+});
+
 module.exports.getTestPouchDBInstance = function (name) {
-  // Use a folder specific to this test so that the database content
-  // will not interfere with any other databases that might be created
-  // during other tests.
-  var dbPath = path.join(module.exports.tmpDirectory(),
-    'pouchdb-test-directory');
-  var LevelDownPouchDB =
-    PouchDB.defaults({db: require('leveldown-mobile'), prefix: dbPath});
   return new LevelDownPouchDB(name);
 };
 


### PR DESCRIPTION
The PouchDB.defaults call was moved so that it gets called only once, because
otherwise, event emitters gets subscribed to many time which caused a warning
like `possible EventEmitter memory leak detected`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/558)
<!-- Reviewable:end -->


<!---
@huboard:{"order":0.001983642578125}
-->
