### PR TITLE
Get rid of the radio toggling at the end of tests

### DIFF
--- a/test/www/jxcore/PerfTest_app.js
+++ b/test/www/jxcore/PerfTest_app.js
@@ -9,8 +9,6 @@
 var testUtils = require('./lib/testUtils');
 var TestFrameworkClient = require('./perf_tests/PerfTestFrameworkClient');
 
-testUtils.toggleRadios(true);
-
 /*------------------------------------------------------------------------------
  code for connecting to the coordinator server
  -----------------------------------------------------------------------------*/

--- a/test/www/jxcore/lib/thali-tape.js
+++ b/test/www/jxcore/lib/thali-tape.js
@@ -153,7 +153,6 @@ function createStream(testServer)
 
     testUtils.logMessageToScreen('Total: ' + total + ', Passed: ' + passed + ', Failed: ' + failed);
     console.log('Total: %d\tPassed: %d\tFailed: %d', total, passed, failed);
-    testUtils.toggleRadios(false);
 
     console.log("****TEST TOOK:  ms ****" );
     console.log("****TEST_LOGGER:[PROCESS_ON_EXIT_SUCCESS]****");
@@ -207,9 +206,13 @@ thaliTape.begin = function() {
   });
 
   testServer.on('disconnect', function () {
-    // We've become disconnected from the test server
-    // Shut down the Wifi & Bluetooth here
-    testUtils.toggleRadios(false);
+    // Just log the error since socket.io will try
+    // to reconnect.
+    console.log('Disconnected from the test server');
+  });
+
+  testServer.on('reconnect', function () {
+    console.log('Reconnected to the test server');
   });
 
   // Wait until we're connected

--- a/test/www/jxcore/perf_tests/PerfTestFrameworkClient.js
+++ b/test/www/jxcore/perf_tests/PerfTestFrameworkClient.js
@@ -156,8 +156,6 @@ function TestFrameworkClient(deviceName, bluetoothAddress, testServer) {
     }
 
     testUtils.logMessageToScreen('fully-closed');
-    console.log('turning Radios off');
-    testUtils.toggleRadios(false);
   });
 }
 

--- a/thali/NextGeneration/thaliMobileNativeWrapper.js
+++ b/thali/NextGeneration/thaliMobileNativeWrapper.js
@@ -445,25 +445,30 @@ var registerToNative = function (methodName, callback) {
 };
 
 registerToNative('peerAvailabilityChanged', function (peers) {
+  logger.info('peerAvailabilityChanged: %s', JSON.stringify(peers));
   // do stuff!
 });
 
 registerToNative('discoveryAdvertisingStateUpdateNonTCP',
   function (discoveryAdvertisingStateUpdateValue) {
+    logger.info('discoveryAdvertisingStateUpdateNonTCP: %s',
+      JSON.stringify(discoveryAdvertisingStateUpdateValue));
     // do stuff!
   }
 );
 
-registerToNative('networkChanged', function (networkChanged) {
+registerToNative('networkChanged', function (networkChangedValue) {
+  logger.info('networkChanged: %s', JSON.stringify(networkChangedValue));
   // The value needs to be assigned here to nonTCPNetworkStatus
   // so that {@link module:thaliMobileNativeWrapper:getNonTCPNetworkStatus}
   // can return it.
-  nonTCPNetworkStatus = networkChanged;
+  nonTCPNetworkStatus = networkChangedValue;
   module.exports.emitter.emit('networkChangedNonTCP', nonTCPNetworkStatus);
 });
 
 registerToNative('incomingConnectionToPortNumberFailed',
   function (portNumber) {
+    logger.info('incomingConnectionToPortNumberFailed: %s', portNumber);
     // do stuff!
   }
 );


### PR DESCRIPTION
The radio toggling at the beginning of the tests was removed as a workaround
for #563. That would be good to put back once a root cause and fix is found,
but even then, it should not be necessary to turn off radios at the end of
tests.

This was originally done for CI where devices didn't reboot in between tests,
but now devices do reboot and thus tests always start from clean radio states.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/572)
<!-- Reviewable:end -->
