### PR TITLE
Fix the broken queue

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -73,7 +73,9 @@ copying and pasting that Cordova development normally requires.
 To set up your desktop environment for development go to Thali_CordovaPlugin/thali/install and run 
 `jx npm run setupDesktop`.
 
-Sudo might be needed because this script installs a symbolic link into your global NPM directory. But if you can get away without using it you will be much happier as using sudo for this (especially on OS/X) seems to cause permission nightmares.
+Sudo might be needed because this script installs a symbolic link into your global NPM directory. But if you can get 
+away without using it you will be much happier as using sudo for this (especially on OS/X) seems to cause permission 
+nightmares.
 
 You can run all the tests by going to Thali_CordovaPlugin/test/www/jxcore and issuing one of the following:
 

--- a/test/www/jxcore/bv_tests/testPromiseQueue.js
+++ b/test/www/jxcore/bv_tests/testPromiseQueue.js
@@ -193,3 +193,38 @@ test('mix enqueue and enqueueAtTop', function (t) {
     fourthPromise = true;
   });
 });
+
+test('queues handled independently', function (t) {
+  var firstQueue = new PromiseQueue();
+  var secondQueue = new PromiseQueue();
+
+  var shortInterval = 10;
+  var longInterval = shortInterval * 100;
+  var longOperationTimeout = null;
+
+  var shortOperation = function (resolve, reject) {
+    setTimeout(function () {
+      resolve();
+    }, shortInterval);
+  };
+  secondQueue.enqueue(shortOperation);
+
+  firstQueue.enqueue(function (resolve, reject) {
+    longOperationTimeout = setTimeout(function () {
+      resolve();
+    }, longInterval);
+  })
+  .then(function () {
+    t.fail();
+    t.end();
+  });
+  firstQueue.enqueue(shortOperation);
+
+  secondQueue.enqueue(shortOperation);
+  secondQueue.enqueue(shortOperation)
+  .then(function () {
+    t.ok(true, 'all short operations completed before the long resolves');
+    clearTimeout(longOperationTimeout);
+    t.end();
+  });
+});

--- a/thali/NextGeneration/promiseQueue.js
+++ b/thali/NextGeneration/promiseQueue.js
@@ -26,10 +26,8 @@ var Promise = require('lie');
  */
 function PromiseQueue () {
   this.globalPromise = Promise.resolve(true);
+  this._promiseFunctionArray = [];
 }
-
-PromiseQueue.prototype.globalPromise = null;
-PromiseQueue.prototype._promiseFunctionArray = [];
 
 /**
  * This is just a resolve or reject function returned by a Promise.


### PR DESCRIPTION
Our promise queue used a share array for all instances, that was just a bug. Now it uses a different array of promises for each queue instance. Thanks to @vjrantal  for fixing this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/586)
<!-- Reviewable:end -->
