### PR TITLE
Remove esversion from .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,4 @@
 {
-  "esversion": 5,
   "eqeqeq": true,
   "noarg": true,
   "undef": true,


### PR DESCRIPTION
This is done, because latest jshint complains this as an error:
`ES5 option is now set per default`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/590)
<!-- Reviewable:end -->
