### PR TITLE
Adds EventEmitter to thaliPeerAction

### DIFF
--- a/thali/NextGeneration/thaliPeerPool/thaliPeerAction.js
+++ b/thali/NextGeneration/thaliPeerPool/thaliPeerAction.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var Promise = require('lie');
+var EventEmitter = require('events').EventEmitter;
+var inherits = require('util').inherits;
 
 /** @module thaliPeerAction */
 
@@ -29,6 +31,7 @@ var peerActionCounter = 0;
  */
 function PeerAction (peerIdentifier, connectionType, actionType)
 {
+  EventEmitter.call(this);
   this._peerIdentifier = peerIdentifier;
   this._connectionType = connectionType;
   this._actionType = actionType;
@@ -36,6 +39,8 @@ function PeerAction (peerIdentifier, connectionType, actionType)
   this._id = peerActionCounter;
   ++peerActionCounter;
 }
+
+inherits(PeerAction, EventEmitter);
 
 /**
  * Records the current state of the action.


### PR DESCRIPTION
ThaliNotificationAction requires eventemitter and I think I can't inherit ThaliNotificationAction from two different parents (ThaliPeerAction and EventEmitter). Please review this makes sense. If not, let's just ignore this request.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/599)
<!-- Reviewable:end -->


<!---
@huboard:{"order":9.5367431640625e-06,"milestone_order":599,"custom_state":""}
-->
