### PR TITLE
#631 - Make kill idempotent

### DIFF
--- a/test/www/jxcore/bv_tests/testThaliPeerPoolInterface.js
+++ b/test/www/jxcore/bv_tests/testThaliPeerPoolInterface.js
@@ -85,3 +85,11 @@ test('#ThaliPeerPoolInterface - make sure we catch kill and dequeue',
       testPeerAction2, 'second item is still in queue');
     t.end();
   });
+
+test('#ThaliPeerPoolInterface - make sure our changes to the action leave ' +
+  'kill as idempotent', function (t) {
+  t.equal(testThaliPeerPool.enqueue(testPeerAction), null, 'good enqueue');
+  t.equal(testPeerAction.kill(), null, 'first kill');
+  t.equal(testPeerAction.kill(), null, 'second NOOP kill');
+  t.end();
+});

--- a/thali/NextGeneration/thaliPeerPool/thaliPeerPoolInterface.js
+++ b/thali/NextGeneration/thaliPeerPool/thaliPeerPoolInterface.js
@@ -97,7 +97,10 @@ ThaliPeerPoolInterface.prototype.enqueue = function (peerAction) {
     assert(self._inQueue[peerAction.getId()] === peerAction, 'Items should ' +
       'not escape the queue without going through kill');
     delete self._inQueue[peerAction.getId()];
-    this._poolScratch.kill.call(peerAction);
+    // This code only needs to run once so we can restore the original kill
+    // to handle future calls.
+    peerAction.kill = this._poolScratch.kill.bind(peerAction);
+    return this._poolScratch.kill.call(peerAction);
   };
   self._inQueue[peerAction.getId()] = peerAction;
   return null;


### PR DESCRIPTION
@juhanak pointed out that actions that went through the pool no longer had
idempotent kill methods.

thaliPeerPoolInterface - We now remove our extra pool specific kill code
after kill is called the first time.

testThaliPeerPoolInterface - Testing that kill doesn't throw when called
multiple times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/634)
<!-- Reviewable:end -->


<!---
@huboard:{"order":200.06453704833984}
-->
