### PR TITLE
Another fix for peer unavailability watcher

### DIFF
--- a/test/www/jxcore/bv_tests/testThaliMobile.js
+++ b/test/www/jxcore/bv_tests/testThaliMobile.js
@@ -440,6 +440,13 @@ function (t) {
     availabilityChangedHandler);
   setupDiscoveryAndFindPeer(t, function (peer, done) {
     checkPeer(t, peer, true);
+    // The timeout is the unavailability threshold plus a bit extra
+    // so that our test verifies the peer is not marked unavailable
+    // too soon. The reason the peer should not be marked unavailable
+    // is that we advertise over SSDP every 500 milliseconds so the
+    // unavailability threshold should never be met when all works
+    // normally.
+    var timeout = ThaliConfig.TCP_PEER_UNAVAILABILITY_THRESHOLD + 500;
     setTimeout(function () {
       ThaliMobile.emitter.removeListener('peerAvailabilityChanged',
         availabilityChangedHandler);
@@ -449,6 +456,6 @@ function (t) {
       t.ok(spy.callCount <= maxAvailabilityChanges,
         'must not receive too many peer availabilities');
       done();
-    }, ThaliConfig.PEER_AVAILABILITY_WATCHER_INTERVAL + 100);
+    }, timeout);
   });
 });

--- a/thali/NextGeneration/thaliMobile.js
+++ b/thali/NextGeneration/thaliMobile.js
@@ -611,11 +611,13 @@ var changePeersUnavailable = function (connectionType) {
   });
 };
 
-var peerHasChanged = function (peer) {
-  var cachedPeer = peerAvailabilities[peer.connectionType][peer.peerIdentifier];
+var updateAndCheckChanges = function (peer) {
+  var cachedPeer =
+    peerAvailabilities[peer.connectionType][peer.peerIdentifier];
   if (!cachedPeer) {
     return true;
   }
+  cachedPeer.availableSince = Date.now();
   if (cachedPeer.hostAddress !== peer.hostAddress ||
       cachedPeer.portNumber !== peer.portNumber) {
     return true;
@@ -644,7 +646,7 @@ var getExtendedPeer = function (peer, connectionType) {
 
 var handlePeer = function (peer, connectionType) {
   peer = getExtendedPeer(peer, connectionType);
-  if (!peerHasChanged(peer)) {
+  if (!updateAndCheckChanges(peer)) {
     return;
   }
   if (peer.hostAddress === null) {


### PR DESCRIPTION
The availability of the peer was not updated properly so peer was marked
unavailable too soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/672)
<!-- Reviewable:end -->