### PR TITLE
V next tompaana multiple issues yarong

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -58,7 +58,7 @@ Android and iOS. This assumes you are running on a Mac with all the right tools.
 3. Go to Thali_CordovaPlugin/test/TestServer
 4. Examine Config_PerfTest.json or Config_UnitTest.json (depending on the test type you are running) and make sure it
 is configured properly.
-5. Run `jx index.js \{\"devices\":\{\"ios\":\"2\",\"android\":\"2\"}}` in that directory on your local PC to start the 
+5. Run `jx index.js \{\"devices\":\{\"ios\":2,\"android\":2}}` in that directory on your local PC to start the 
 coordination server. Obviously edit the device counts passed on the command line to reflect the actual test
 environment.
 6. Deploy and run the tests on your two Android or two iPhone devices.

--- a/test/www/jxcore/bv_tests/disabled/testIdentityExchangeEndpoint.js
+++ b/test/www/jxcore/bv_tests/disabled/testIdentityExchangeEndpoint.js
@@ -44,7 +44,7 @@ var test = tape({
   setup: function(t) {
     setUpServer().then(function() {
       server.on('error', function(err) {
-        t.comment("Server emitted an error event - " + JSON.stringify(err));
+        t.pass(("Server emitted an error event - " + JSON.stringify(err));
       });
       if (jxcore.utils.OSInfo().isMobile) {
         var levelDownPouchDb = identityExchangeTestUtils.LevelDownPouchDB();

--- a/test/www/jxcore/bv_tests/disabled/testLiveIdentityExchange.js
+++ b/test/www/jxcore/bv_tests/disabled/testLiveIdentityExchange.js
@@ -36,7 +36,7 @@ var test = tape({
 
 test('Now do an identity Exchange with the real live system!', function(t) {
   if (!jxcore.utils.OSInfo().isMobile) {
-    t.comment("Skipping test because we aren't running on a mobile platform");
+    t.pass(("Skipping test because we aren't running on a mobile platform");
     t.end();
     return;
   }
@@ -48,14 +48,14 @@ test('Now do an identity Exchange with the real live system!', function(t) {
   var identityExchange = new IdentityExchange(thaliApp, thaliServer.address().port, thaliReplicationManager,
     dbName);
   thaliReplicationManager._emitter.on(ThaliEmitter.events.PEER_AVAILABILITY_CHANGED, function(peer) {
-    t.comment("We found a peer - " + JSON.stringify(peer));
+    t.pass(("We found a peer - " + JSON.stringify(peer));
   });
   var peerIdentityExchangeHandler = function(peer) {
-    t.comment("We got a peer to do identity exchange with! - " + JSON.stringify(peer));
+    t.pass(("We got a peer to do identity exchange with! - " + JSON.stringify(peer));
     if (peer.peerAvailable) {
       identityExchange.removeListener(IdentityExchange.Events.PeerIdentityExchange,
         peerIdentityExchangeHandler);
-      t.comment("We are going to try and do an identity exchange with the peer");
+      t.pass(("We are going to try and do an identity exchange with the peer");
       identityExchange.executeIdentityExchange(peer.peerIdentifier, peer.peerName, function(err, code) {
         t.notOk(err, "Did we get an error on executeIdentityExchange?");
         identityExchangeTestUtils.checkCode(t, code);

--- a/test/www/jxcore/bv_tests/disabled/testSmallerHashStateMachine.js
+++ b/test/www/jxcore/bv_tests/disabled/testSmallerHashStateMachine.js
@@ -131,7 +131,7 @@ function endlessMockConnectionTableLoop(t, expectedPeerId, port, noChannelBindin
   var mock = new MockConnectionTable(function(peerId, lastLookupTime) {
     t.equal(expectedPeerId, peerId);
     if (!noChannelBindingErrors) {
-      t.comment('lookupTime: ' + lookupTime + ', lastLookupTime: ' + lastLookupTime);
+      t.pass('lookupTime: ' + lookupTime + ', lastLookupTime: ' + lastLookupTime);
       t.ok(lookupTime === 0 || lookupTime === lastLookupTime);
     }
 

--- a/test/www/jxcore/bv_tests/testThaliMobileNativeWrapper.js
+++ b/test/www/jxcore/bv_tests/testThaliMobileNativeWrapper.js
@@ -137,46 +137,27 @@ test('error returned with bad router', function (t) {
 
 var testPath = '/test';
 function trivialEndToEndTestScaffold(t, needManualNotify,
-                                     pskIdtoSecret, pskIdentity, pskKey, 
+                                     pskIdtoSecret, pskIdentity, pskKey,
                                      testData, callback) {
   var router = express.Router();
   router.get(testPath, function (req, res) {
     res.send(testData);
   });
 
-  var selectedPeer = null;
-  var peerAvailabilityHandler = function (peer) {
-    if (selectedPeer && peer.peerIdentifier !== selectedPeer) {
-      return;
-    }
-    // Ignore peer unavailable events
-    if (peer.portNumber === null) {
-      return;
-    }
-    selectedPeer = peer.peerIdentifier;
-    t.ok(true, 'found a peer! ' + JSON.stringify(peer));
-    thaliMobileNativeWrapper.emitter.removeListener(
-      'nonTCPPeerAvailabilityChangedEvent',
-      peerAvailabilityHandler
-    );
-
-    var end = function () {
-      callback ? callback(peer) : t.end();
-    };
-
-    testUtils.get('127.0.0.1', peer.portNumber, testPath, pskIdentity, pskKey)
-    .then(function (responseBody) {
-      t.equal(responseBody, testData, 'response body should match testData');
-      end();
-    })
-    .catch(function (error) {
-      t.fail(error);
-      end();
-    });
+  var end = function (peerId, fail) {
+    callback ? callback(peerId, fail) : t.end();
   };
 
-  thaliMobileNativeWrapper.emitter.on('nonTCPPeerAvailabilityChangedEvent',
-    peerAvailabilityHandler);
+  testUtils.getSamePeerWithRetry(testPath, pskIdentity, pskKey)
+    .then(function (response) {
+      t.equal(response.httpResponseBody, testData,
+        'response body should match testData');
+      end(response.peerId);
+    })
+    .catch(function (error) {
+      t.fail('fail in trivialEndtoEndTestScaffold - ' + error);
+      end(null, error);
+    });
 
   thaliMobileNativeWrapper.start(router, pskIdtoSecret)
     .then(function () {
@@ -656,24 +637,27 @@ test('test to coordinate connection cut', function (t) {
 });
 
 test('can do HTTP requests after connections are cut', function (t) {
-  // TODO:
-  // toggleBluetooth (on Android) does not actually wait for Bluetooth to be
-  // enabled. There is a bug on this (#717) and after it is fixed, delete the
-  // Android specific code in this test case.
-  if (jxcore.utils.OSInfo().isAndroid) {
-    testUtils.toggleBluetooth(true);
+  // Turn Bluetooth back on so that Android can operate
+  // (iOS does not require separate call to operate since
+  // killConnections is more like a single-shot thing).
 
-    setTimeout(function() {
-      endToEndWithStateCheck(t);
-    }, 20000);
+  if (jxcore.utils.OSInfo().isAndroid) {
+    var networkChangeHandler = function(networkChangedValue) {
+      t.pass('Delete me - we got a network changed value ' + networkChangedValue);
+      if (networkChangedValue.bluetoothLowEnergy &&
+          networkChangedValue.bluetooth) {
+        thaliMobileNativeWrapper.emitter.removeListener('networkChangedNonTCP',
+         networkChangeHandler);
+        endToEndWithStateCheck(t);
+      }
+    };
+    thaliMobileNativeWrapper.emitter.on('networkChangedNonTCP',
+      networkChangeHandler);
+
+    t.pass('Turning bluetooth on');
+    testUtils.toggleBluetooth(true);
   } else {
-    // Turn Bluetooth back on so that Android can operate
-    // (iOS does not require separate call to operate since
-    // killConnections is more like a single-shot thing).
-    testUtils.toggleBluetooth(true)
-    .then(function () {
-      endToEndWithStateCheck(t);
-    });
+    endToEndWithStateCheck(t);
   }
 });
 
@@ -687,9 +671,9 @@ test('will fail bad PSK connection between peers', function (t) {
 test('We provide notification when a listener dies and we recreate it',
   function (t) {
     var recreatedPort = null;
-    trivialEndToEndTest(t, false, function (peer) {
+    trivialEndToEndTest(t, false, function (peerId) {
       function recreatedHandler(record) {
-        t.equal(record.peerIdentifier, peer.peerIdentifier, 'same ids');
+        t.equal(record.peerIdentifier, peerId, 'same ids');
         recreatedPort = record.portNumber;
       }
 
@@ -700,46 +684,49 @@ test('We provide notification when a listener dies and we recreate it',
         thaliMobileNativeWrapper._getServersManager()
           .removeListener('listenerRecreatedAfterFailure', recreatedHandler);
         thaliMobileNativeWrapper.emitter
-          .removeListener('nonTCPPeerAvailabilityChangedEvent', 
-            nonTCPAvaiHandler);
+          .removeListener('nonTCPPeerAvailabilityChangedEvent',
+            nonTCPAvailableHandler);
         t.end();
       }
-      
-      function nonTCPAvaiHandler(record) {
-        if (record.peerIdentifier !== peer.peerIdentifier) {
-          logger.debug('Peer identifiers do not match: '
-            + record.peerIdentifier + ' !== ' + peer.peerIdentifier);
-          return;
-        }
 
+      function nonTCPAvailableHandler(record) {
         // TODO:
         // There is a race condition when this test is ran on Android:
         // This function is called just before recreatedHandler leading
         // to recreatedPort being null.
         // Re-enable the check below once #719 is fixed.
+        // Note that due to other changes we also need to add in a test to
+        // make sure we are looking at an event for the right peerID
         /*if (!recreatedPort ||
           recreatedPort && record.portNumber !== recreatedPort) {
           logger.debug('No recreated port or port numbers do not match: '
             + record.portNumber + ' !== ' + recreatedPort);
           return;
         }*/
-
-        testUtils.get('127.0.0.1', record.portNumber, testPath, pskIdentity,
-                      pskKey)
-          .then(function (responseBody) {
-            t.equal(responseBody, testData, 'matching bodies');
-            exit();
-          })
-          .catch(function (err) {
-            t.fail(err);
-            exit();
-          });
       }
-      
+
+      testUtils.getSamePeerWithRetry(testPath, pskIdentity, pskKey, peerId)
+        .then(function (response) {
+          t.equal(response.httpResponseBody, testData,
+            'recreate - response body should match testData');
+          exit();
+        })
+        .catch(function (error) {
+          t.fail('fail in recreate test - ' + error);
+          exit();
+        });
+
       thaliMobileNativeWrapper.emitter.on('nonTCPPeerAvailabilityChangedEvent',
-        nonTCPAvaiHandler);
-      
-      thaliMobileNativeWrapper._getServersManager().
-        _peerServers[peer.peerIdentifier].server._mux.destroy();
+        nonTCPAvailableHandler);
+
+      t.pass('About to destroy connection to peer');
+
+      try {
+        thaliMobileNativeWrapper._getServersManager().
+          _peerServers[peerId].server._mux.destroy();
+      } catch (err) {
+        t.fail('destroy failed with - ' + err);
+        exit();
+      }
     });
   });

--- a/test/www/jxcore/bv_tests/testThaliMobileNativeWrapper.js
+++ b/test/www/jxcore/bv_tests/testThaliMobileNativeWrapper.js
@@ -5,7 +5,6 @@ var net = require('net');
 var Promise = require('lie');
 var sinon = require('sinon');
 var testUtils = require('../lib/testUtils.js');
-var logger = require('thali/thalilogger')('testThaliMobileNativeWrapper');
 
 if (typeof Mobile === 'undefined') {
   return;

--- a/test/www/jxcore/lib/testUtils.js
+++ b/test/www/jxcore/lib/testUtils.js
@@ -14,7 +14,6 @@ var thaliConfig = require('thali/NextGeneration/thaliConfig');
 
 var notificationBeacons =
   require('thali/NextGeneration/notification/thaliNotificationBeacons');
-var thaliMobileNativeWrapper = require('thali/NextGeneration/thaliMobileNativeWrapper');
 
 var doToggle = function (toggleFunction, on) {
   if (typeof Mobile === 'undefined') {
@@ -350,6 +349,9 @@ module.exports.getWithAgent = function (host, port, path, agent) {
  */
 module.exports.getSamePeerWithRetry = function (path, pskIdentity, pskKey,
                                                 selectedPeerId) {
+  // We don't load thaliMobileNativeWrapper until after the tests have started
+  // running so we pick up the right version of mobile
+  var thaliMobileNativeWrapper = require('thali/NextGeneration/thaliMobileNativeWrapper');
   return new Promise(function (resolve, reject) {
     var retryCount = 0;
     var MAX_TIME_TO_WAIT_IN_MILLISECONDS = 1000 * 30 * 2;

--- a/test/www/jxcore/lib/testUtils.js
+++ b/test/www/jxcore/lib/testUtils.js
@@ -14,6 +14,7 @@ var thaliConfig = require('thali/NextGeneration/thaliConfig');
 
 var notificationBeacons =
   require('thali/NextGeneration/notification/thaliNotificationBeacons');
+var thaliMobileNativeWrapper = require('thali/NextGeneration/thaliMobileNativeWrapper');
 
 var doToggle = function (toggleFunction, on) {
   if (typeof Mobile === 'undefined') {
@@ -254,7 +255,7 @@ module.exports.extractPreAmble = function (beaconStreamWithPreAmble) {
   return beaconStreamWithPreAmble.slice(0, preAmbleSizeInBytes);
 };
 
-module.exports.extractBeacon = function (beaconStreamWithPreAmble, 
+module.exports.extractBeacon = function (beaconStreamWithPreAmble,
                                          beaconIndexToExtract) {
   var beaconStreamNoPreAmble =
     beaconStreamWithPreAmble.slice(preAmbleSizeInBytes);
@@ -298,7 +299,7 @@ module.exports._get = function (host, port, path, options) {
     });
     // Wait for 15 seconds since the request can take a while
     // in mobile environment over a non-TCP transport.
-    request.setTimeout(15 * 1000 * 1000);
+    request.setTimeout(15 * 1000);
     request.end();
   });
 };
@@ -325,4 +326,112 @@ module.exports.getWithAgent = function (host, port, path, agent) {
     agent: agent
   };
   return module.exports._get(host, port, path, options);
+};
+
+/**
+ * @typedef {Object} peerAndBody
+ * @property {string} httpResponseBody
+ * @property {string} peerId
+ */
+
+/**
+ * This function will grab the first peer it can via nonTCPAvailableHandler and
+ * will try to issue the GET request. If it fails then it will continue to
+ * listen to nonTCPAvailableHandler until it sees a port for the same PeerID
+ * and will try the GET again. It will repeat this process if there are
+ * failures until the timer runs out.
+ *
+ * @param {string} path
+ * @param {string} pskIdentity
+ * @param {Buffer} pskKey
+ * @param {?string} [selectedPeerId] This is only used for a single test that
+ * needs to reconnect to a known peer, otherwise it is null.
+ * @returns {Promise<Error | peerAndBody>}
+ */
+module.exports.getSamePeerWithRetry = function (path, pskIdentity, pskKey,
+                                                selectedPeerId) {
+  return new Promise(function (resolve, reject) {
+    var retryCount = 0;
+    var MAX_TIME_TO_WAIT_IN_MILLISECONDS = 1000 * 30 * 2;
+    var exitCalled = false;
+    var peerID = selectedPeerId;
+    var getRequestPromise = null;
+
+    function exitCall(success, failure) {
+      if (exitCalled) {
+        return;
+      }
+      exitCalled = true;
+      clearTimeout(timeoutId);
+      thaliMobileNativeWrapper.emitter
+        .removeListener('nonTCPPeerAvailabilityChangedEvent',
+          nonTCPAvailableHandler);
+      return failure ? reject(failure) : resolve(
+        {
+          httpResponseBody: success,
+          peerId: peerID
+        });
+    }
+
+    var timeoutId = setTimeout(function () {
+      exitCall(null, new Error('Timer expired'));
+    }, MAX_TIME_TO_WAIT_IN_MILLISECONDS);
+
+    function tryAgain(portNumber, err) {
+      ++retryCount;
+      logger.warn('Retry count for getSamePeerWithRetry is ' + retryCount);
+      getRequestPromise =
+        module.exports.get('127.0.0.1', portNumber, path, pskIdentity, pskKey);
+      getRequestPromise
+        .then(function (result) {
+          exitCall(result);
+        })
+        .catch(function (err) {
+          logger.debug('getSamePeerWithRetry got an error it will retry - ' +
+            err);
+        });
+    }
+
+    function nonTCPAvailableHandler(record) {
+      // Ignore peer unavailable events
+      if (record.portNumber === null) {
+        if (peerID && record.peerIdentifier === peerID) {
+          logger.warn('We got a peer unavailable notification for a ' +
+            'peer we are looking for.');
+        }
+        return;
+      }
+
+      if (peerID && record.peerIdentifier !== peerID) {
+        return;
+      }
+
+      logger.debug('We got a peer ' + JSON.stringify(record));
+
+      if (!peerID) {
+        peerID = record.peerIdentifier;
+        return tryAgain(record.portNumber);
+      }
+
+
+      // We have a predefined peerID
+      if (!getRequestPromise) {
+        return tryAgain(record.portNumber);
+      }
+
+      getRequestPromise
+        .then(function () {
+          // In theory this could maybe happen if a connection somehow got
+          // cut before we were notified of a successful result thus causing
+          // the system to automatically issue a new port, but that is
+          // unlikely
+        })
+        .catch(function (err) {
+          return tryAgain(record.portNumber, err);
+        });
+    }
+
+    thaliMobileNativeWrapper.emitter.on('nonTCPPeerAvailabilityChangedEvent',
+      nonTCPAvailableHandler);
+  });
 };


### PR DESCRIPTION
README - Fixed a typo

testIdentityExchangeEndpoint, testLiveIdentityExchange, testSmallerHashStateMachine - Just removing calls to t.comment which we don't currently support. Changed them to t.pass. We aren't using these
tests right now but we will and I didn't want them to crash us.

testThaliMobileNative - Added a timeout to the final test so it shouldn't hang everything if it fails. I also
made the syntax error result (which usually happens when Bluetooth fails) into a recoverable error.

testThaliMobileNativeWrapper - Hardened the tests so that they would try in the face of failed connections or connections that failed mid-stream.

testUtils - Created a hardened GET function that can retry across failures

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/724)
<!-- Reviewable:end -->
