### PR TITLE
#842 Removed the app.js work around

### DIFF
--- a/test/www/js/thali_main.js
+++ b/test/www/js/thali_main.js
@@ -35,15 +35,14 @@
 
     jxcore.isReady(function () {
       if (window.ThaliPermissions) {
-        // requestLocationPermission ensures that the application has 
+        // requestLocationPermission ensures that the application has
         // the required ACCESS_COARSE_LOCATION permission in Android.
         window.ThaliPermissions.requestLocationPermission(function () {
           console.log('Application has the required permission.');
           loadMainFile();
         }, function (error) {
           console.log('Location permission not granted. Error: ' + error);
-          console.log('****TEST_LOGGER:[PROCESS_ON_EXIT_FAILED]****');
-          navigator.app.exitApp();
+          exitWithFailureLog();
         });
       } else {
         loadMainFile();
@@ -55,12 +54,7 @@
     jxcore('app.js').loadMainFile(function (ret, err) {
       if (err) {
         console.log('app.js file failed to load : ' + JSON.stringify(err));
-        // This is an error scenario, which occurs in CI, but should not
-        // be an issue with the app code so inform CI that this was a
-        // success case. This can be made an error after this is fixed:
-        // https://github.com/thaliproject/Thali_CordovaPlugin/issues/594
-        console.log('****TEST_LOGGER:[PROCESS_ON_EXIT_SUCCESS]****');
-        navigator.app.exitApp();
+        exitWithFailureLog();
       } else {
         jxcore_ready();
       }
@@ -72,6 +66,11 @@
     jxcore('setLogCallback').call(logCallback);
     document.getElementById('ClearLogButton').addEventListener('click', ClearLog);
     console.log('UIApp is all set and ready!');
+  }
+
+  function exitWithFailureLog() {
+    console.log('****TEST_LOGGER:[PROCESS_ON_EXIT_FAILED]****');
+    navigator.app.exitApp();
   }
 
   function nameCallback(name) {


### PR DESCRIPTION
Removed success log on `app.js` loading failure.
Added failure log on `app.js` loading failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/845)
<!-- Reviewable:end -->


<!---
@huboard:{"order":889.2222677804444,"milestone_order":845,"custom_state":""}
-->
