### PR TITLE
Specing how we can simulate the iOS layer in the wifi mock

### DIFF
--- a/test/www/jxcore/lib/wifiBasedNativeMock.js
+++ b/test/www/jxcore/lib/wifiBasedNativeMock.js
@@ -93,6 +93,77 @@ proxyquire('thali/NextGeneration/thaliWifiInfrastructure',
  * For testing purposes if callNative or registerToNative do not get all the
  * parameters they were expecting then a "Bad Arguments" exception MUST be
  * thrown.
+ *
+ * ## Mocking iOS
+ *
+ * The file was original written from the perspective of Android and the
+ * connect method (which we also used to use on iOS). But the new code uses
+ * multiConnect for iOS. The challenge with this change is how do we model
+ * a MCSession on the WiFi Mock? It was relatively easy to model an Android
+ * Bluetooth socket because the mux in node is allowed to create exactly one
+ * TCP/IP connection to the native layer. If node kills that connection then it
+ * means that node wants the associated Bluetooth socket to die. And if the
+ * native layer kills the connection it tells node that for some reason the
+ * Bluetooth socket was lost. So by just killing that single TCP/IP connection
+ * we could model kill the mocked Bluetooth socket either from node or from
+ * the 'native' layer.
+ *
+ * But with iOS there can be many or even no connections to the native TCP/IP
+ * listener. So the life span of the MCSession is largely separate from the
+ * listener. I say 'largely' because if the listen is closed all together then
+ * that tells the node layer that the MCSession was lost but this is not
+ * something that is easily detected by the node layer so it isn't terribly
+ * useful for us. More importantly, there is no way for the remote peer to
+ * directly trigger the closure of the TCP/IP listener, at least not via any
+ * TCP/IP mechanism. Where as a remote peer can trigger the closure of the
+ * the single TCP/IP connection by closing its relayed connection.
+ *
+ * So what we need is an explicit way to model MCSessions in the mock when we
+ * are emulating iOS. We had thought of using the mux layer for this, in other
+ * words we could put the iOS code on top of the TCPServersManager code
+ * which would then run on top of the WiFiMock which would then run on top of
+ * the real WiFi code. This is workable but it's so complex it made our heads
+ * hurt. So we decided to go with a simple solution.
+ *
+ * When a multiConnect method is received we will connect to the advertised
+ * port and address that came over WiFi originally and we will connect to
+ * an express endpoint we will add to the router called /inviteToSession. We
+ * will support a POST request to that endpoint with a query argument on the
+ * URL that contains a UUID to identify the session the remote peer is being
+ * invited to. Remember that we will need to create an ACL for this (and the
+ * other end points mentioned here) with a pre-defined secret since we
+ * require all connections to run over PSK. Right now the response to
+ * /inviteToSession will always be 200 OK. This is because we don't yet have
+ * the functionality to allow peers to reject incoming session requests other
+ * than for DOS reasons. So once the requesting peer gets 200 OK it can treat
+ * the MCSession as established and continue with the multiConnect request.
+ *
+ * We will add a second endpoint under the same ACL called /endSession. This
+ * endpoint also takes a query argument that contains a UUID. This identifies
+ * the MCSession ID that is being closed. Either peer can send this to the
+ * other. This enables us to simulate MCSession failures due both to the peer
+ * who created the session and the peer who is a member of the session. A call
+ * to this endpoint on the peer who initiated the session (so we have to track
+ * which IDs we initiated) MUST cause a multiConnectConnectionFailureCallback
+ * event to be fired to tell Node that the session is gone. The TCP listener
+ * associated with the original multiConnect that created the session MUST also
+ * be closed and all existing connections terminated.
+ *
+ * If a peer who was invited to a session (e.g. received an /inviteToSession
+ * request) then receives a /endSession request with the same ID then this
+ * signals that the TCP/IP listener that is handling WiFi requests to be
+ * relayed to that peer's local router is to be shut down and all client
+ * connections to that router shut down. The most common reason for this to
+ * happens is that the initiating peer called the native disconnect method.
+ *
+ * In the case that peer A initiated a session with peer B and now peer B
+ * wants to terminate that session (e.g. the test code on peer B called the
+ * killConnections method which would kill everything) then this could trigger
+ * a call to the /endSession endpoint on peer A. The result is very similar to
+ * what would have happened had peer A called disconnect on the session. That
+ * is, the TCP listener waiting for node requests to relay across WiFi would
+ * be closed down. Existing connections would be closed and the
+ * multiConnectConnectionFailureCallback would be called.
  */
 
 /**


### PR DESCRIPTION
@artemjackson please talk with @andrew-aladev as you will need to use a bunch of interfaces he knows well including setting up the new endpoints, figuring out the ACLs, etc. Also please, please, please, re-read the specs for multiConnect, multiConnectResolve, disconnect, multiConnectConnectionFailure, killConnections, etc. in thaliMobileNative and thaliMobileNativeWrapper. The mock needs to meet all those behaviors. And keep in mind that part of resolving this bug is enhancing our node tests with the right APIs to validate the mock's behavior. These tests should go right into testthaliMobileNative since these are the same tests that should be used with the native layer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/963)
<!-- Reviewable:end -->