### PR TITLE
Move off JXcore where we can

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,8 +63,8 @@ jx npm run test-coordinated;ERROR_ABORT
 
 # Verify that docs can be generated
 #cd $PROJECT_ROOT/thali/;ERROR_ABORT
-#jx npm run createPublicDocs;ERROR_ABORT
-#jx npm run createInternalDocs;ERROR_ABORT
+#npm run createPublicDocs;ERROR_ABORT
+#npm run createInternalDocs;ERROR_ABORT
 
 # Make sure we are back in the project root folder
 # after the test execution

--- a/test/README.md
+++ b/test/README.md
@@ -72,13 +72,12 @@ To run the mobile tests:
 
 1. If you have a sibling directory to Thali_CordovaPlugin called ThaliTest, now would be a good time to delete it.
 1. Go to Thali_CordovaPlugin/thali/install
-2. Run either `jx npm run setupUnit` or `jx npm run setupPerf` depending on what type of test project you want to
-create. On Windows, run `./setUpTests.sh UnitTest_app.js` or `./setupTests.sh PerfTest_app.js` on the latest
+2. Run `npm run setupUnit`. On Windows, run `./setUpTests.sh UnitTest_app.js` or `./setupTests.sh PerfTest_app.js` on the latest
 Git Bash.
 2.1 The script will create a sibling directory to Thali_CordovaPlugin called ThaliTest and will compile it for both
 Android and iOS. This assumes you are running on a Mac with all the right tools.
 3. Go to Thali_CordovaPlugin/test/TestServer
-4. Examine Config_PerfTest.json or Config_UnitTest.json (depending on the test type you are running) and make sure it
+4. Examine UnitTestConfig.js and make sure it
 is configured properly.
 5. Run `jx index.js \{\"devices\":\{\"ios\":2,\"android\":2\}\}` in that directory on your local PC to start the 
 coordination server. Obviously edit the device counts passed on the command line to reflect the actual test
@@ -134,7 +133,7 @@ one can develop and debug directly in the Thali_CordovaPlugin directory. There i
 copying and pasting that Cordova development normally requires.
 
 To set up your desktop environment for development go to 
-Thali_CordovaPlugin/thali/install and run `jx npm run setupDesktop`.
+Thali_CordovaPlugin/thali/install and run `npm run setupDesktop`.
 
 Sudo might be needed because this script installs a symbolic link into your global NPM directory. But if you can get 
 away without using it you will be much happier as using sudo for this (especially on OS/X) seems to cause permission 

--- a/test/www/jxcore/installCustomPouchDB.js
+++ b/test/www/jxcore/installCustomPouchDB.js
@@ -21,9 +21,9 @@ function getPackageJsonVersion(packageName) {
 
 function installPackage(packageName, version, callback) {
   var packageVersion = packageName + '@' + version;
-  exec('jx install ' + packageVersion, function (error, stdout, stderr) {
+  exec('npm install ' + packageVersion, function (error, stdout, stderr) {
     if (error) {
-      console.log('jx install of ' + packageVersion + ' failed with error ' +
+      console.log('npm install of ' + packageVersion + ' failed with error ' +
         error + ', stdout: ' + stdout + ', stderr: ' + stderr);
       return callback(error);
     }

--- a/thali/install/install.js
+++ b/thali/install/install.js
@@ -92,7 +92,7 @@ function getEtagFromEtagFile(depotName, branchName, directoryToInstallIn) {
 function getReleaseConfig() {
   var configFileName = path.join(__dirname, '../', 'package.json');
 
-  return fs.readFileAsync(configFileName, "utf-8")
+  return fs.readFileAsync(configFileName, 'utf-8')
     .then(function (data) {
       var conf;
       try {
@@ -100,7 +100,7 @@ function getReleaseConfig() {
         if (conf && conf.thaliInstall) {
           return conf.thaliInstall;
         }
-        return Promise.reject("Configuration error!");
+        return Promise.reject('Configuration error!');
       }
       catch (err) {
         return Promise.reject(new Error(err));
@@ -294,7 +294,7 @@ function fetchAndInstallJxCoreCordovaPlugin(baseDir, jxCoreVersionNumber, jxCore
     var jxcBin =
       path.join(__dirname, 'node_modules', 'jxc', 'bin', 'jxc.bin.js');
     var jxcInstall =
-      spawn('jx',
+      spawn('node',
         [
           jxcBin, 'install', jxCoreVersionNumber,
           '--use-url', jxCoreUrl
@@ -337,7 +337,8 @@ module.exports = function (callback, appRootDirectory) {
       thaliBranchName = conf.thali.branchName;
       btconnectorlib2 = conf.btconnectorlib2;
 
-      return fetchAndInstallJxCoreCordovaPlugin(appRootDirectory, conf["jxcore-cordova"], conf["jxcore-cordova-url"]);
+      return fetchAndInstallJxCoreCordovaPlugin(appRootDirectory,
+        conf['jxcore-cordova'], conf['jxcore-cordova-url']);
     })
     .then(function () {
       if (doesMagicDirectoryNamedExist(thaliDontCheckIn)) {
@@ -349,15 +350,17 @@ module.exports = function (callback, appRootDirectory) {
         return installGitHubZip(thaliProjectName, thaliDepotName,
                                 thaliBranchName, thaliDontCheckIn);
       }
-    }).then(function(thaliCordovaPluginUnZipResult){
+    }).then(function (thaliCordovaPluginUnZipResult){
       // This step is used to prepare the gradle.properties file
       // containing the btconnectorlib2 version
-      var projectDir = createUnzippedDirectoryPath(thaliDepotName, thaliBranchName, thaliDontCheckIn);
-      var gradleFileName = path.join(projectDir, 'src', 'android', 'gradle.properties');
+      var projectDir = createUnzippedDirectoryPath(thaliDepotName,
+                                            thaliBranchName, thaliDontCheckIn);
+      var gradleFileName = path.join(projectDir, 'src', 'android',
+                                      'gradle.properties');
 
       return fs.writeFileAsync(gradleFileName,
-        "btconnectorlib2Version=" + btconnectorlib2)
-        .then(function() {
+        'btconnectorlib2Version=' + btconnectorlib2)
+        .then(function () {
           return thaliCordovaPluginUnZipResult;
         });
     })
@@ -375,10 +378,12 @@ module.exports = function (callback, appRootDirectory) {
             // The step below is required, because the Android after prepare
             // Cordova hook depends on external node modules that need to be
             // installed.
-            console.log('Running jx npm install in: ' + appScriptsFolder);
+            console.log('Running npm install in: ' + appScriptsFolder);
             return childProcessExecPromise(
-              'jx npm install --no-optional --autoremove "*.gz"',
+              'npm install --no-optional --production',
                appScriptsFolder);
+          }).then(function () {
+            return childProcessExecPromise('find . -name "*.gz" -delete');
           }).then(function () {
             return fs.writeFileAsync(weAddedPluginsFile, 'yes');
           });

--- a/thali/install/setUpDesktop.sh
+++ b/thali/install/setUpDesktop.sh
@@ -10,15 +10,15 @@ set -e
 
 cd `dirname $0`
 cd ../../test/TestServer
-jx npm install --no-optional
-jx generateServerAddress.js
+npm install --no-optional
+node generateServerAddress.js
 cd ../../thali
-jx npm install --no-optional
-jx npm link
+npm install --no-optional
+npm link
 cd install
-jx npm install --no-optional
+npm install --no-optional
 cd ../../test/www/jxcore
-jx npm link thali
-jx installCustomPouchDB.js
-jx npm install --no-optional
+npm link thali
+node installCustomPouchDB.js
+npm install --no-optional
 

--- a/thali/install/setUpTests.sh
+++ b/thali/install/setUpTests.sh
@@ -21,8 +21,8 @@ cd `dirname $0`
 cd ../..
 repositoryRoot=$(pwd)
 cd test/TestServer
-jx npm install --no-optional
-jx generateServerAddress.js $2
+npm install --no-optional
+node generateServerAddress.js $2
 cd $repositoryRoot/..
 cordova create ThaliTest com.test.thalitest ThaliTest
 mkdir -p ThaliTest/thaliDontCheckIn/localdev
@@ -42,8 +42,9 @@ cd ThaliTest
 #cordova platform add ios
 cordova platform add android
 cd www/jxcore
-jx installCustomPouchDB.js
-jx npm install $repositoryRoot/thali --save --no-optional --autoremove "*.gz"
+node installCustomPouchDB.js
+npm install $repositoryRoot/thali --save --no-optional --production
+find . -name "*.gz" -delete
 
 if [ $runningInMinGw == true ]; then
     # On Windows the package.json file will contain an invalid local file URI for Thali,
@@ -57,7 +58,7 @@ fi
 # SuperTest which is used by some of the BVTs include a PEM file (for private
 # keys) that makes Android unhappy so we remove it below in addition to the gz
 # files.
-jx npm install --no-optional --autoremove "*.gz,*.pem"
+npm install --no-optional --production
 
 # In case autoremove fails to delete the files, delete them explicitly.
 find . -name "*.gz" -delete
@@ -75,4 +76,4 @@ cordova build android --release --device
 #    cordova build ios --device
 #fi
 
-echo "Remember to start the test coordination server by running jx index.js"
+echo "Remember to start the test coordination server by running node index.js"

--- a/thali/installCordovaPlugin.js
+++ b/thali/installCordovaPlugin.js
@@ -22,7 +22,7 @@ exec('cordova info', function (error) {
     process.exit(1);
   }
   var installDirectory = path.join(__dirname, 'install');
-  exec('jx npm install --no-optional --autoremove "*.gz"',
+  exec('npm install --no-optional --production & find . -name "*.gz" -delete',
         { cwd: installDirectory },
     function (error, stdout, stderr) {
       // Log the output in all cases since it might contain useful

--- a/thali/package.json
+++ b/thali/package.json
@@ -2,7 +2,7 @@
   "name": "thali",
   "version": "2.1.0",
   "description": "Thali Cordova Plugin",
-  "main": "thalireplicationmanager.js",
+  "main": "NextGeneration/thaliManager.js",
   "dependencies": {
     "body-parser": "1.13.3",
     "express": "4.13.3",


### PR DESCRIPTION
build.sh - The change is just to jsdoc comments that aren't even active

README.md - Just updating to npm and removing instructions about perf
tests since they don't currently work

installCustomPouchDB.js - We can install packages using npm instead of jx

install.js - Fixing JCSC compliance issues and launching JXC with node
instead of jx. Moved cordova plugin install to npm and added in production
switch so we don't get dev dependencies

setUpDesktop.sh - Turns out everything seems to work with node so switched
there. Didn't use --production because we might want to debug some of this
stuff but I admit that is a pretty weak argument.

setUpTests.sh - Moved test server install to node as well as address
generation. Moved others to node/npm. Appears to work.

installCordovaPlugin.js - Installs Thali using node

package.json - Just updating main

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1025)
<!-- Reviewable:end -->