### PR TITLE
#1059 Random `testThaliNotificationClient` test failure

### DIFF
--- a/test/www/jxcore/bv_tests/testThaliNotificationClient.js
+++ b/test/www/jxcore/bv_tests/testThaliNotificationClient.js
@@ -13,6 +13,8 @@ var ThaliNotificationClient =
   require('thali/NextGeneration/notification/thaliNotificationClient');
 var ThaliMobileNativeWrapper =
   require('thali/NextGeneration/thaliMobileNativeWrapper');
+var ThaliNotificationAction =
+  require('thali/NextGeneration/notification/thaliNotificationAction');
 
 var ThaliPeerPoolDefault =
   require('thali/NextGeneration/thaliPeerPool/thaliPeerPoolDefault');
@@ -377,31 +379,47 @@ test('Action fails because of a bad hostname.', function (t) {
   // Connection is tried RETRY_TIMEOUTS.length times
 
   // Make timeouts shorter (kill will return values to original)
-  ThaliNotificationClient.RETRY_TIMEOUTS =
-    [100, 300, 600];
+  var retryTimeouts = [100, 300, 600];
+  ThaliNotificationClient.RETRY_TIMEOUTS = retryTimeouts;
 
   var requestCount = 0;
   var failCount = 0;
 
-  // Simulates how peer pool runs actions
-  var enqueue = function (action) {
-    requestCount++;
-    var keepAliveAgent = new http.Agent({ keepAlive: true });
-    action.start(keepAliveAgent).then( function () {
-      t.fail('This action should fail always.');
-      t.end();
-    }).catch( function ( ) {
-      failCount++;
-    });
+  var testResolutionEvent = function (peerId, resolution) {
+    t.equal(
+      resolution,
+      ThaliNotificationAction.ActionResolution.NETWORK_PROBLEM,
+      'action should be resolved with NETWORK_PROBLEM error'
+    );
   };
 
-  sinon.stub(globals.peerPoolInterface, 'enqueue', enqueue);
+  // Simulates how peer pool runs actions
+  var enqueueStub = sinon.stub(
+    globals.peerPoolInterface,
+    'enqueue',
+    function (action) {
+      requestCount++;
+      var keepAliveAgent = new http.Agent({ keepAlive: true });
+      action.eventEmitter.on(
+        ThaliNotificationAction.Events.Resolved,
+        testResolutionEvent
+      );
+      action.start(keepAliveAgent).then(function () {
+        t.fail('This action should fail always.');
+        finishTest(true);
+      }).catch(function () {
+        failCount++;
+      }).then(function () {
+        if (requestCount - 1 === retryTimeouts.length) {
+          finishTest();
+        }
+      });
+    }
+  );
 
   var notificationClient =
     new ThaliNotificationClient(globals.peerPoolInterface,
       globals.targetDeviceKeyExchangeObjects[0]);
-
-  notificationClient.start([]);
 
   var TCPEvent = {
     peerIdentifier: 'id123',
@@ -411,18 +429,35 @@ test('Action fails because of a bad hostname.', function (t) {
     suggestedTCPTimeout: 10000
   };
 
+  var finishTest = function (skipChecks) {
+    if (!skipChecks) {
+      t.equals(
+        requestCount - 1,
+        retryTimeouts.length,
+        'correct number of requests'
+      );
+      t.equals(
+        failCount - 1,
+        retryTimeouts.length,
+        'correct number of failures'
+      );
+      var entry = notificationClient.peerDictionary.get('id123');
+      t.equals(
+        entry.peerState,
+        ThaliPeerDictionary.peerState.RESOLVED,
+        'correct final peer state'
+      );
+    }
+    enqueueStub.restore();
+    notificationClient.stop();
+    t.end();
+  };
+
+  notificationClient.start([]);
+
   // New peer with TCP connection
   notificationClient._peerAvailabilityChanged(TCPEvent);
 
-  // Waits 5 seconds. And checks results
-  setTimeout( function () {
-    t.equals(requestCount-1, ThaliNotificationClient.RETRY_TIMEOUTS.length);
-    t.equals(failCount-1, ThaliNotificationClient.RETRY_TIMEOUTS.length);
-    var entry = notificationClient.peerDictionary.get('id123');
-    t.equals(entry.peerState, ThaliPeerDictionary.peerState.RESOLVED);
-    notificationClient.stop();
-    t.end();
-  }, 5000);
 });
 
 test('hostaddress is removed when the action is running. ', function (t) {


### PR DESCRIPTION
"Bad hostname" test now checks request retries count to perform results
verification instead of 5s timeout (sometimes requests take more than 5
seconds total)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1180)
<!-- Reviewable:end -->