### PR TITLE
#1165 Possible workaround

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-### START - JXcore Test Server --------...............................
+### START - JXcore Test Server --------..............................
 ### Testing environment prepares separate packages for each node.
 ### Package builder calls this script with each node's IP address
 ### Make sure multiple calls to this script file compiles the application file

--- a/thali/NextGeneration/replication/thaliReplicationPeerAction.js
+++ b/thali/NextGeneration/replication/thaliReplicationPeerAction.js
@@ -244,7 +244,8 @@ ThaliReplicationPeerAction.prototype.start = function (httpAgentPool) {
         self._reject = reject;
         self._replicationTimer();
         self._cancelReplication = remoteDB.replicate.to(self._dbName, {
-          live: true
+          live: true,
+          retry: true
         })
         .on('paused', function (err) {
           logger.debug(

--- a/thali/NextGeneration/replication/thaliReplicationPeerAction.js
+++ b/thali/NextGeneration/replication/thaliReplicationPeerAction.js
@@ -244,8 +244,7 @@ ThaliReplicationPeerAction.prototype.start = function (httpAgentPool) {
         self._reject = reject;
         self._replicationTimer();
         self._cancelReplication = remoteDB.replicate.to(self._dbName, {
-          live: true,
-          retry: true
+          live: true
         })
         .on('paused', function (err) {
           logger.debug(

--- a/thali/NextGeneration/replication/thaliSendNotificationBasedOnReplication.js
+++ b/thali/NextGeneration/replication/thaliSendNotificationBasedOnReplication.js
@@ -381,9 +381,10 @@ ThaliSendNotificationBasedOnReplication.prototype._setUpChangeListener =
           var milliSecondsUntilNextRefresh =
             soonestPossibleRefresh - Date.now();
 
-          if (milliSecondsUntilNextRefresh >= 0) {
-            self._updateOnExpiration(milliSecondsUntilNextRefresh);
+          if (milliSecondsUntilNextRefresh < 0) {
+            milliSecondsUntilNextRefresh = 0;
           }
+          self._updateOnExpiration(milliSecondsUntilNextRefresh);
         }
       })
       .on('complete', function (info) {

--- a/thali/NextGeneration/replication/thaliSendNotificationBasedOnReplication.js
+++ b/thali/NextGeneration/replication/thaliSendNotificationBasedOnReplication.js
@@ -90,7 +90,7 @@ ThaliSendNotificationBasedOnReplication.UPDATE_WINDOWS_BACKGROUND = 10000;
  * @public
  * @type {number}
  */
-ThaliSendNotificationBasedOnReplication.MAXIMUM_NUMBER_OF_PEERS_TO_NOTIFY = 10;
+ThaliSendNotificationBasedOnReplication.MAXIMUM_NUMBER_OF_PEERS_TO_NOTIFY = 2;
 
 /**
  * Takes an ecdh public key value as a buffer and creates the doc ID to find

--- a/thali/NextGeneration/replication/thaliSendNotificationBasedOnReplication.js
+++ b/thali/NextGeneration/replication/thaliSendNotificationBasedOnReplication.js
@@ -381,7 +381,9 @@ ThaliSendNotificationBasedOnReplication.prototype._setUpChangeListener =
           var milliSecondsUntilNextRefresh =
             soonestPossibleRefresh - Date.now();
 
-          self._updateOnExpiration(milliSecondsUntilNextRefresh);
+          if (milliSecondsUntilNextRefresh >= 0) {
+            self._updateOnExpiration(milliSecondsUntilNextRefresh);
+          }
         }
       })
       .on('complete', function (info) {


### PR DESCRIPTION
We faced with the issue #1165 because sometimes somehow `self._updateOnExpiration` got **negative** `milliSecondsUntilNextRefresh`. So `self._updateOnExpiration` wont reset `beaconRefreshTimerManager` and we get the  `AssertionError`.

At least the tests with this workaround pass on 10 local instances 5 times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1216)
<!-- Reviewable:end -->