### PR TITLE
Mostly linting, maybe fixing

### DIFF
--- a/test/www/jxcore/UnitTest_app.js
+++ b/test/www/jxcore/UnitTest_app.js
@@ -68,16 +68,18 @@ ThaliMobile.getNetworkStatus()
       logger.debug('My device name is: %s', name);
       testUtils.setName(name);
 
-      networkTypes.reduce(function (sequence, networkType) {
+      return networkTypes.reduce(function (sequence, networkType) {
         return sequence
           .then(function () {
             logger.debug('Running for ' + networkType + ' network type');
             global.NETWORK_TYPE = networkType;
             require('./runTests.js');
+            return null;
           });
       }, Promise.resolve())
       .catch(function (error) {
         logger.error(error.message + '\n' + error.stack);
+        return null;
       });
     });
   });

--- a/test/www/jxcore/bv_tests/testThaliManagerCoordinated.js
+++ b/test/www/jxcore/bv_tests/testThaliManagerCoordinated.js
@@ -7,7 +7,6 @@ if (!tape.coordinated) {
 
 var testUtils = require('../lib/testUtils.js');
 
-var extend = require('js-extend').extend;
 var fs = require('fs-extra-promise');
 var path = require('path');
 var crypto = require('crypto');
@@ -16,9 +15,7 @@ var PouchDB = require('pouchdb');
 var ExpressPouchDB = require('express-pouchdb');
 var LeveldownMobile = require('leveldown-mobile');
 
-var sinon = require('sinon');
-
-var PouchDBGenerator = require('thali/NextGeneration/utils/pouchDBGenerator');
+var pouchDBGenerator = require('thali/NextGeneration/utils/pouchDBGenerator');
 var thaliConfig = require('thali/NextGeneration/thaliConfig');
 var ThaliManager = require('thali/NextGeneration/thaliManager');
 var ThaliPeerPoolDefault =
@@ -41,7 +38,7 @@ var publicBase64KeyForLocalDevice = ecdhForLocalDevice.getPublicKey('base64');
 // PouchDB name should be the same between peers.
 var DB_NAME = 'ThaliManagerCoordinated';
 
-PouchDB = PouchDBGenerator(PouchDB, defaultDirectory, {
+PouchDB = pouchDBGenerator(PouchDB, defaultDirectory, {
   defaultAdapter: LeveldownMobile
 });
 
@@ -311,7 +308,7 @@ test('test repeat write 2', function (t) {
     var oldDocs = partnerKeys.map(function (partnerKey) {
       return {
         _id: partnerKey.toString('base64'),
-        test1: true, 
+        test1: true,
         test2: true
       };
     });

--- a/test/www/jxcore/bv_tests/testThaliMobileNative.js
+++ b/test/www/jxcore/bv_tests/testThaliMobileNative.js
@@ -222,7 +222,7 @@ function connectToPeer(peer, retries, successCb, failureCb, quitSignal) {
         logger.info('Scheduling a connect retry - retries left: ' + retries);
         var timeoutCancel = setTimeout(function () {
           quitSignal && quitSignal.removeTimeout(timeoutCancel);
-          connectToPeer(peer, retries, successCb, failureCb);
+          connectToPeer(peer, retries, successCb, failureCb, quitSignal);
         }, TIME_BETWEEN_RETRIES);
         quitSignal && quitSignal.addTimeout(timeoutCancel, successCb);
       } else {

--- a/thali/NextGeneration/utils/pouchDBGenerator.js
+++ b/thali/NextGeneration/utils/pouchDBGenerator.js
@@ -65,17 +65,17 @@ function PouchDBGenerator(PouchDB, defaultDirectory, options) {
 
   options = extend({}, options);
 
-  // This is a workround for #970.
+  // This is a workaround for #970.
   var CustomEventEmitter = function () {
     return EventEmitter.apply(this, arguments);
-  }
+  };
 
   inherits(CustomEventEmitter, EventEmitter);
 
   inherits(PouchAlt, PouchDB);
 
   PouchAlt.preferredAdapters = PouchDB.preferredAdapters.slice();
-  Object.keys(PouchDB).forEach(function(key) {
+  Object.keys(PouchDB).forEach(function (key) {
     if (!(key in PouchAlt) ) {
       PouchAlt[key] = PouchDB[key];
     }
@@ -83,17 +83,17 @@ function PouchDBGenerator(PouchDB, defaultDirectory, options) {
 
   // This is a workaround for #870.
   PouchAlt.prototype.info = function () {
-    var self = this;
     return PouchAlt.super_.prototype.info.apply(this, arguments)
     .catch(function () {
       return { update_seq: 0 };
     });
-  }
+  };
 
   // This is a workaround for #970.
   PouchAlt.prototype.on =
   PouchAlt.prototype.addListener = function (type, listener) {
     var self = this;
+
     // We don't want PouchDB to catch our exception from 'listener'.
     // We want to cancel current PouchDB action and emit 'error' with exception.
     return PouchAlt.super_.prototype.addListener.call(this, type, function () {
@@ -103,7 +103,7 @@ function PouchDBGenerator(PouchDB, defaultDirectory, options) {
         self.emit('error', e);
       }
     });
-  }
+  };
 
   // This is a workaround for #970.
   // 'Changes' has an 'EventEmitter' too, but it isn't exported.


### PR DESCRIPTION
UnitTest_app.js - These changes make Bluebird happy, otherwise it will
complain about "a promise was created in a handler but was not returned
from it"

testThaliManagerCoordinated - Linting

thaliSendNotificationBasedOnReplication - Added an assert on one of
our constructor arguments, covered a theoretical edge case where we
could end up with a negative time value. Clarified that one of the functions
handles an arg different than stated.

thaliManager - Linting

pouchDBGeneratior - Linting

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1248)
<!-- Reviewable:end -->
