### PR TITLE
Spawning test in separate process

### DIFF
--- a/test/TestServer/HttpServer.js
+++ b/test/TestServer/HttpServer.js
@@ -90,6 +90,13 @@ Server.prototype._present = function (socket, deviceInfo) {
   this.emit('present', device);
 }
 
+Server.prototype.disconnectAll = function () {
+  var sockets = this._io.sockets.sockets;
+  Object.keys(sockets).forEach(function(socketName) {
+    sockets[socketName].disconnect(true);
+  });
+}
+
 Server.prototype._exit = function () {
   this._io.close();
 }

--- a/test/TestServer/TestFramework.js
+++ b/test/TestServer/TestFramework.js
@@ -21,35 +21,7 @@ function TestFramework(options) {
   TestFramework.super_.call(this);
 
   this._setOptions(options);
-
-  var devices    = this._options.devices;
-  var minDevices = this._options.minDevices;
-  this.platforms = Object.keys(devices)
-  .reduce(function (platforms, platformName) {
-    var count    = devices[platformName];
-    var minCount = minDevices[platformName];
-    asserts.isNumber(count);
-    asserts.isNumber(minCount);
-
-    if (count === -1) {
-      var timeout = self._options.waiting_for_devices_timeout;
-      asserts.isNumber(timeout);
-      setTimeout(function () {
-        self.startTests(platformName);
-      }, timeout);
-    }
-
-    if (count === -1 || count > 0) {
-      platforms[platformName] = {
-        count: count,
-        minCount: minCount,
-        devices: [],
-        deviceIndexes: {},
-        state: TestFramework.platformStates.created
-      };
-    }
-    return platforms;
-  }, {});
+  this.reset();
 }
 
 inherits(TestFramework, EventEmitter);
@@ -101,6 +73,41 @@ TestFramework.prototype._setOptions = function (options) {
       format('platform name: \'%s\' is required', requiredPlatformName)
     );
   });
+}
+
+TestFramework.prototype.reset = function () {
+  var self = this;
+
+  logger.debug('reset');
+
+  var devices    = this._options.devices;
+  var minDevices = this._options.minDevices;
+  this.platforms = Object.keys(devices)
+  .reduce(function (platforms, platformName) {
+    var count    = devices[platformName];
+    var minCount = minDevices[platformName];
+    asserts.isNumber(count);
+    asserts.isNumber(minCount);
+
+    if (count === -1) {
+      var timeout = self._options.waiting_for_devices_timeout;
+      asserts.isNumber(timeout);
+      setTimeout(function () {
+        self.startTests(platformName);
+      }, timeout);
+    }
+
+    if (count === -1 || count > 0) {
+      platforms[platformName] = {
+        count: count,
+        minCount: minCount,
+        devices: [],
+        deviceIndexes: {},
+        state: TestFramework.platformStates.created
+      };
+    }
+    return platforms;
+  }, {});
 }
 
 TestFramework.prototype.addDevice = function (device) {

--- a/test/www/jxcore/UnitTest_app.js
+++ b/test/www/jxcore/UnitTest_app.js
@@ -14,6 +14,7 @@ var config = require('./config.json');
 var objectAssign = require('object-assign');
 process.env = objectAssign(process.env, config.env);
 
+var runTests = require('./runTests');
 var logger = require('./lib/testLogger')('UnitTest_app');
 var testUtils = require('./lib/testUtils');
 var ThaliMobile = require('thali/NextGeneration/thaliMobile');
@@ -70,12 +71,11 @@ ThaliMobile.getNetworkStatus()
 
       return networkTypes.reduce(function (sequence, networkType) {
         return sequence
-          .then(function () {
-            logger.debug('Running for ' + networkType + ' network type');
-            global.NETWORK_TYPE = networkType;
-            require('./runTests.js');
-            return null;
-          });
+        .then(function () {
+          logger.debug('Running for ' + networkType + ' network type');
+          global.NETWORK_TYPE = networkType;
+          return runTests();
+        });
       }, Promise.resolve())
       .catch(function (error) {
         logger.error(error.message + '\n' + error.stack);

--- a/test/www/jxcore/bv_tests/testThaliMobile.js
+++ b/test/www/jxcore/bv_tests/testThaliMobile.js
@@ -499,11 +499,11 @@ var setupDiscoveryAndFindPeers = function (t, router, callback) {
 
 test('peer should be found once after listening and discovery started',
 function (t) {
-  var spy = sinon.spy();
+  var peers = {};
   var availabilityChangedHandler = function (peer) {
     // Only count changes that mark peer becoming available.
     if (peer.hostAddress !== null && peer.portNumber !== null) {
-      spy();
+      peers[peer.connectionType + ':' + peer.peerIdentifier] = true;
     }
   };
   var peerFound = false;
@@ -528,7 +528,7 @@ function (t) {
       // The maximum amount is the participants count minues ourseld times 2,
       // because the same participant may be reached via Wifi and non-TCP.
       var maxAvailabilityChanges = (t.participants.length - 1) * 2;
-      t.ok(spy.callCount <= maxAvailabilityChanges,
+      t.ok(Object.keys(peers).length <= maxAvailabilityChanges,
         'must not receive too many peer availabilities');
       done();
     }, timeout);

--- a/test/www/jxcore/lib/CoordinatedClient.js
+++ b/test/www/jxcore/lib/CoordinatedClient.js
@@ -169,7 +169,6 @@ CoordinatedClient.prototype._discard = function (data) {
     logger.debug('device discarded as surplus from the test server');
   });
 
-  // We are waiting for 'disconnect' event.
   self._state = CoordinatedClient.states.completed;
 }
 
@@ -198,15 +197,12 @@ CoordinatedClient.prototype._disqualify = function (data) {
     });
   });
 
-  if (!data) {
-    // We are waiting for 'disconnect' event.
-    self._state = CoordinatedClient.states.completed;
-  }
+  self._state = CoordinatedClient.states.completed;
 }
 
 CoordinatedClient.prototype._disconnect = function () {
   if (this._state === CoordinatedClient.states.completed) {
-    logger.debug('test client disconnected');
+    logger.debug('completed device disconnected from the test server');
     this._succeed();
   } else {
     // Just log the error since socket.io will try to reconnect.
@@ -230,7 +226,6 @@ CoordinatedClient.prototype._complete = function (data) {
     logger.debug('all tests completed');
   });
 
-  // We are waiting for 'disconnect' event.
   self._state = CoordinatedClient.states.completed;
 }
 

--- a/test/www/jxcore/lib/CoordinatedClient.js
+++ b/test/www/jxcore/lib/CoordinatedClient.js
@@ -120,11 +120,13 @@ CoordinatedClient.prototype._reconnect = function () {
 }
 
 CoordinatedClient.prototype._newConnection = function () {
-  assert(
-    this._state === CoordinatedClient.states.created ||
-    this._state === CoordinatedClient.states.connected,
-    'we should be in created or connected state'
-  );
+  if(
+    this._state !== CoordinatedClient.states.created &&
+    this._state !== CoordinatedClient.states.connected
+  ) {
+    // We can ignore this reconnect event.
+    return;
+  }
   this._state = CoordinatedClient.states.connected;
 
   this._emit('present', {
@@ -147,8 +149,16 @@ CoordinatedClient.prototype._schedule = function (data) {
 
   this._emit('schedule_confirmed', data)
   .then(function () {
+    // Each begin schedule must provide an uniq tape instance
+    // See https://github.com/substack/tape#var-htest--testcreateharness
+    // and https://github.com/substack/tape#var-stream--testcreatestreamopts
+    // for more details
+
+    var htest = tape.createHarness();
+    htest.createStream().pipe(process.stdout);
+
     var promises = self._tests.map(function (test) {
-      return self._scheduleTest(test);
+      return self._scheduleTest(htest, test);
     });
     return Promise.all(promises);
   })
@@ -282,7 +292,7 @@ CoordinatedClient.prototype._emit = function (event, data, externalOptions) {
   });
 }
 
-CoordinatedClient.prototype._scheduleTest = function (test) {
+CoordinatedClient.prototype._scheduleTest = function (htest, test) {
   var self = this;
 
   function runEvent (event) {
@@ -404,14 +414,14 @@ CoordinatedClient.prototype._scheduleTest = function (test) {
   }
 
   return new Promise(function (resolve, reject) {
-    tape('setup', function (tape) {
+    htest('setup', function (tape) {
       tape.sync = sync.bind(undefined, tape, test.options.setupTimeout);
 
       processEvent(tape, 'setup_' + test.name, test.options.setup, test.options.setupTimeout)
       .catch(reject);
     });
 
-    tape(test.name, function (tape) {
+    htest(test.name, function (tape) {
       tape.sync = sync.bind(undefined, tape, test.options.testTimeout);
 
       Promise.try(function () {
@@ -432,7 +442,7 @@ CoordinatedClient.prototype._scheduleTest = function (test) {
       .catch(reject);
     });
 
-    tape('teardown', function (tape) {
+    htest('teardown', function (tape) {
       tape.sync = sync.bind(undefined, tape, test.options.teardownTimeout);
 
       processEvent(tape, 'teardown_' + test.name, test.options.teardown, test.options.teardownTimeout)

--- a/test/www/jxcore/lib/CoordinatedTape.js
+++ b/test/www/jxcore/lib/CoordinatedTape.js
@@ -64,7 +64,7 @@ CoordinatedThaliTape.begin = function (options) {
     thaliTape._begin();
     return tests.concat(thaliTape._getTests());
   }, []);
-  CoordinatedThaliTape.instances = [];
+  CoordinatedThaliTape.instances = SimpleThaliTape.instances = [];
 
   if (tests.length === 0) {
     logger.warn('we have no tests in this file');

--- a/test/www/jxcore/lib/CoordinatedTape.js
+++ b/test/www/jxcore/lib/CoordinatedTape.js
@@ -68,7 +68,7 @@ CoordinatedThaliTape.begin = function (options) {
 
   if (tests.length === 0) {
     logger.warn('we have no tests in this file');
-    return;
+    return Promise.resolve();
   }
 
   var _testClient = new CoordinatedClient(

--- a/test/www/jxcore/lib/CoordinatedTape.js
+++ b/test/www/jxcore/lib/CoordinatedTape.js
@@ -59,20 +59,25 @@ CoordinatedThaliTape.prototype._getTests = function () {
   });
 }
 
-CoordinatedThaliTape.begin = function (platform, version, hasRequiredHardware, nativeUTFailed) {
+CoordinatedThaliTape.begin = function (options) {
   var tests = CoordinatedThaliTape.instances.reduce(function (tests, thaliTape) {
     thaliTape._begin();
     return tests.concat(thaliTape._getTests());
   }, []);
   CoordinatedThaliTape.instances = [];
 
+  if (tests.length === 0) {
+    logger.warn('we have no tests in this file');
+    return;
+  }
+
   var _testClient = new CoordinatedClient(
     tests,
     CoordinatedThaliTape.uuid,
-    platform,
-    version,
-    hasRequiredHardware,
-    !!nativeUTFailed
+    options.platform,
+    options.version,
+    options.hasRequiredHardware,
+    options.nativeUTFailed
   );
 
   // Only used for testing purposes.
@@ -88,15 +93,16 @@ CoordinatedThaliTape.begin = function (platform, version, hasRequiredHardware, n
     });
   })
   .then(function () {
-    logger.debug('all tests succeed');
-    logger.debug('****TEST_LOGGER:[PROCESS_ON_EXIT_SUCCESS]****');
+    logger.debug(
+      'all unit tests succeeded, platformName: \'%s\'',
+      options.platform
+    );
   })
   .catch(function (error) {
     logger.error(
-      'tests failed, error: \'%s\', stack: \'%s\'',
-      error.toString(), error.stack
+      'failed to run unit tests, platformName: \'%s\', error: \'%s\', stack: \'%s\'',
+      options.platform, error.toString(), error.stack
     );
-    logger.debug('****TEST_LOGGER:[PROCESS_ON_EXIT_FAILED]****');
     return Promise.reject(error);
   });
 }

--- a/test/www/jxcore/lib/SimpleTape.js
+++ b/test/www/jxcore/lib/SimpleTape.js
@@ -97,7 +97,7 @@ SimpleThaliTape.prototype.addTest = function (name, canBeSkipped, fun) {
   return this._handler;
 }
 
-SimpleThaliTape.prototype._runTest = function (test) {
+SimpleThaliTape.prototype._runTest = function (htest, test) {
   var self = this;
 
   // Test was skipped.
@@ -155,15 +155,12 @@ SimpleThaliTape.prototype._runTest = function (test) {
       });
     }
 
-    // TODO This can be implemented using 'tape/lib/test' directly.
-    // Example is 'tape.createHarness' https://github.com/substack/tape/blob/master/index.js#L103
-
-    tape('setup', function (tape) {
+    htest('setup', function (tape) {
       processResult(tape, self._options.setupTimeout)
       self._options.setup(tape);
     });
 
-    tape(test.name, function (tape) {
+    htest(test.name, function (tape) {
       processResult(tape, self._options.testTimeout);
 
       Promise.try(function () {
@@ -185,7 +182,7 @@ SimpleThaliTape.prototype._runTest = function (test) {
       .catch(reject);
     });
 
-    tape('teardown', function (tape) {
+    htest('teardown', function (tape) {
       processResult(tape, self._options.teardownTimeout);
       tape.once('end', resolve);
       self._options.teardown(tape);
@@ -200,7 +197,7 @@ SimpleThaliTape.prototype._runTest = function (test) {
   });
 }
 
-SimpleThaliTape.prototype._begin = function () {
+SimpleThaliTape.prototype._begin = function (htest) {
   var self = this;
   assert(
     this._state === SimpleThaliTape.states.created,
@@ -211,7 +208,7 @@ SimpleThaliTape.prototype._begin = function () {
   var skippedTests = [];
   return Promise.all(
     this._tests.map(function (test) {
-      return self._runTest(test)
+      return self._runTest(htest, test)
       .catch(function (error) {
         if (error.message === 'skipped') {
           skippedTests.push(test.name);
@@ -237,9 +234,17 @@ SimpleThaliTape.begin = function (options) {
   var thaliTapes = SimpleThaliTape.instances;
   SimpleThaliTape.instances = [];
 
+  // Each begin call must provide an uniq tape instance
+  // See https://github.com/substack/tape#var-htest--testcreateharness
+  // and https://github.com/substack/tape#var-stream--testcreatestreamopts
+  // for more details
+
+  var htest = tape.createHarness();
+  htest.createStream().pipe(process.stdout);
+
   return Promise.all(
     thaliTapes.map(function (thaliTape) {
-      return thaliTape._begin();
+      return thaliTape._begin(htest);
     })
   )
   .then(function (skippedTests) {

--- a/test/www/jxcore/lib/SimpleTape.js
+++ b/test/www/jxcore/lib/SimpleTape.js
@@ -233,9 +233,7 @@ SimpleThaliTape.prototype._resolveInstance = function () {
   SimpleThaliTape.instances.push(this);
 }
 
-// Note that version, hasRequiredHardware and nativeUTFailed fields are not used and are added
-// here for consistency with CoordinatedTape
-SimpleThaliTape.begin = function (platform, version, hasRequiredHardware, nativeUTFailed) {
+SimpleThaliTape.begin = function (options) {
   var thaliTapes = SimpleThaliTape.instances;
   SimpleThaliTape.instances = [];
 
@@ -247,7 +245,7 @@ SimpleThaliTape.begin = function (platform, version, hasRequiredHardware, native
   .then(function (skippedTests) {
     logger.debug(
       'all unit tests succeeded, platformName: \'%s\'',
-      platform
+      options.platform
     );
     skippedTests = skippedTests.reduce(function (allTests, tests) {
       return allTests.concat(tests);
@@ -255,14 +253,12 @@ SimpleThaliTape.begin = function (platform, version, hasRequiredHardware, native
     logger.debug(
       'skipped tests: \'%s\'', JSON.stringify(skippedTests)
     );
-    logger.debug('****TEST_LOGGER:[PROCESS_ON_EXIT_SUCCESS]****');
   })
   .catch(function (error) {
     logger.error(
       'failed to run unit tests, platformName: \'%s\', error: \'%s\', stack: \'%s\'',
-      platform, error.toString(), error.stack
+      options.platform, error.toString(), error.stack
     );
-    logger.debug('****TEST_LOGGER:[PROCESS_ON_EXIT_FAILED]****');
     return Promise.reject(error);
   });
 }

--- a/test/www/jxcore/lib/thaliTape.js
+++ b/test/www/jxcore/lib/thaliTape.js
@@ -29,6 +29,7 @@ var test = tape({
 require('./utils/process');
 
 var exports;
+
 if (typeof jxcore === 'undefined' || typeof Mobile !== 'undefined') {
   // On mobile, or outside of jxcore (some dev scenarios)
   // we use the server-coordinated thaliTape.

--- a/test/www/jxcore/runTests.js
+++ b/test/www/jxcore/runTests.js
@@ -132,43 +132,50 @@ function runTest (testFile, options) {
   });
 }
 
-testUtils.hasRequiredHardware()
-.then(function (hasRequiredHardware) {
-  return testUtils.getOSVersion()
-  .then(function (version) {
-    var currentPlatform = platform.name;
-    // Our current platform can be 'darwin', 'linux', 'windows', etc.
-    // Our 'thaliTape' expects all these platforms will be named as 'desktop'.
-    if (!platform.isMobile || !currentPlatform) {
-      currentPlatform = 'desktop';
-    }
+function run () {
+  testUtils.hasRequiredHardware()
+  .then(function (hasRequiredHardware) {
+    return testUtils.getOSVersion()
+    .then(function (version) {
+      var currentPlatform = platform.name;
+      // Our current platform can be 'darwin', 'linux', 'windows', etc.
+      // Our 'thaliTape' expects all these platforms will be named as 'desktop'.
+      if (!platform.isMobile || !currentPlatform) {
+        currentPlatform = 'desktop';
+      }
 
-    var nativeUTFailed = global.nativeUTFailed;
-    if (nativeUTFailed === undefined || nativeUTFailed === null) {
-      nativeUTFailed = false;
-    }
+      var nativeUTFailed = global.nativeUTFailed;
+      if (nativeUTFailed === undefined || nativeUTFailed === null) {
+        nativeUTFailed = false;
+      }
 
-    var options = {
-      platform:            currentPlatform,
-      version:             version,
-      hasRequiredHardware: hasRequiredHardware,
-      nativeUTFailed:      nativeUTFailed
-    };
+      var options = {
+        platform:            currentPlatform,
+        version:             version,
+        hasRequiredHardware: hasRequiredHardware,
+        nativeUTFailed:      nativeUTFailed
+      };
 
-    return Promise.mapSeries(testFiles, function (testFile) {
-      return runTest(testFile, options);
+      return Promise.mapSeries(testFiles, function (testFile) {
+        return runTest(testFile, options);
+      });
     });
+  })
+  .then(function () {
+    logger.debug('****TEST_LOGGER:[PROCESS_ON_EXIT_SUCCESS]****');
+    process.exit(0);
+  })
+  .catch(function (error) {
+    logger.error(
+      'unexpected error: \'%s\', stack: \'%s\'',
+      error.toString(), error.stack
+    );
+    logger.debug('****TEST_LOGGER:[PROCESS_ON_EXIT_FAILED]****');
+    process.exit(1);
   });
-})
-.then(function () {
-  logger.debug('****TEST_LOGGER:[PROCESS_ON_EXIT_SUCCESS]****');
-  process.exit(0);
-})
-.catch(function (error) {
-  logger.error(
-    'unexpected error: \'%s\', stack: \'%s\'',
-    error.toString(), error.stack
-  );
-  logger.debug('****TEST_LOGGER:[PROCESS_ON_EXIT_FAILED]****');
-  process.exit(1);
-});
+}
+
+if (!module.parent) {
+  run();
+}
+module.exports = run;

--- a/test/www/jxcore/runTests.js
+++ b/test/www/jxcore/runTests.js
@@ -7,6 +7,9 @@ var assert       = require('assert');
 var fs           = require('fs-extra-promise');
 var path         = require('path');
 var randomString = require('randomstring');
+var spawn        = require('child_process').spawn;
+var objectAssign = require('object-assign');
+var Promise      = require('bluebird');
 
 
 // Before including anything serious from thali we want to ensure
@@ -18,18 +21,11 @@ if (!process.env.SSDP_NT) {
   });
 }
 
-var thaliTape = require('./lib/thaliTape');
+require('./lib/utils/process.js');
 var testUtils = require('./lib/testUtils');
 var logger    = require('./lib/testLogger')('runTests');
 
 var platform = require('thali/NextGeneration/utils/platform');
-
-// The global.Mobile object is replaced here after thaliTape
-// has been required so that thaliTape can pick up the right
-// test framework to be used.
-if (typeof Mobile === 'undefined') {
-  global.Mobile = require('./lib/wifiBasedNativeMock.js')();
-}
 
 var DEFAULT_TESTS_DIRECTORY = 'bv_tests';
 
@@ -38,44 +34,44 @@ function isFileNameValid (fileName) {
   return /^test.*?\.js$/i.test(fileName);
 }
 
-function getTestFromFile (directory, fileName) {
+function getTestFile (directory, fileName) {
   assert(isFileNameValid(fileName), 'file name should be valid');
   var filePath = path.resolve(path.join(directory, fileName));
   assert(fs.existsSync(filePath), 'test file should exist');
   return filePath;
 }
 
-function getTestsFromDirectory (directory) {
-  var tests = fs.readdirSync(directory)
+function getTestFilesFromDirectory (directory) {
+  var testFiles = fs.readdirSync(directory)
   .filter(function (fileName) {
     return isFileNameValid(fileName);
   })
   .map(function (fileName) {
     return path.resolve(path.join(directory, fileName));
   });
-  tests.forEach(function (filePath) {
+  testFiles.forEach(function (filePath) {
     assert(fs.existsSync(filePath), 'test file should exist');
   });
-  assert(tests.length > 0, 'we should have at least one test');
-  return tests;
+  assert(testFiles.length > 0, 'we should have at least one test');
+  return testFiles;
 }
 
-function getTestsFromPath (testPath) {
+function getTestFilesFromPath (testPath) {
   if (fs.isDirectorySync(testPath)) {
-    return getTestsFromDirectory(testPath);
+    return getTestFilesFromDirectory(testPath);
   } else {
-    return [getTestFromFile(
+    return [getTestFile(
       path.dirname (testPath),
       path.basename(testPath)
     )];
   }
 }
 
-var tests;
+var testFiles;
 if (process.argv.length < 3) {
-  tests = getTestsFromDirectory(DEFAULT_TESTS_DIRECTORY);
+  testFiles = getTestFilesFromDirectory(DEFAULT_TESTS_DIRECTORY);
 } else if (process.argv.length === 3) {
-  tests = getTestsFromPath(process.argv[2]);
+  testFiles = getTestFilesFromPath(process.argv[2]);
 } else {
   logger.warn(
     'arguments won\'t be used:',
@@ -85,31 +81,81 @@ if (process.argv.length < 3) {
     })
     .join(', ')
   );
-  tests = getTestsFromPath(process.argv[2]);
+  testFiles = getTestFilesFromPath(process.argv[2]);
 }
 
 var currentPlatform = platform.name;
 // Our current platform can be 'darwin', 'linux', 'windows', etc.
 // Our 'thaliTape' expects all these platforms will be named as 'desktop'.
-if (!platform.isMobile) {
+if (!platform.isMobile || !currentPlatform) {
   currentPlatform = 'desktop';
+}
+
+function instanceLogger () {
+  this.write.apply(this, arguments);
+}
+
+var nativeUTFailed = global.nativeUTFailed;
+if (nativeUTFailed === undefined || nativeUTFailed === null) {
+  nativeUTFailed = false;
 }
 
 testUtils.hasRequiredHardware()
 .then(function (hasRequiredHardware) {
   return testUtils.getOSVersion()
   .then(function (version) {
-    return thaliTape.begin(tests, {
+    var options = {
       platform:            currentPlatform,
       version:             version,
       hasRequiredHardware: hasRequiredHardware,
-      nativeUTFailed:      global.nativeUTFailed
+      nativeUTFailed:      nativeUTFailed
+    };
+
+    // We can have here jxcore or node.
+    var node = process.env['_'] || 'node';
+
+    return Promise.mapSeries(testFiles, function (testFile) {
+      return new Promise(function (resolve, reject) {
+        logger.debug('spawning test: \'%s\'', testFile);
+
+        var instance = spawn(
+          node,
+          ['./spawnTest.js', testFile, JSON.stringify(options)],
+          objectAssign({}, process.env)
+        );
+
+        instance.stdout
+        .on('data', instanceLogger.bind(process.stdout))
+        .on('error', instanceLogger.bind(process.stderr));
+
+        instance.stderr
+        .on('data', instanceLogger.bind(process.stderr))
+        .on('error', instanceLogger.bind(process.stderr));
+
+        instance.on('exit', function (code, signal) {
+          logger.debug('finished test: \'%s\'', testFile);
+          if (code === 0 && signal === null) {
+            resolve();
+          } else {
+            reject(new Error(format(
+              'test process failed with code: %d, signal: \'%s\'',
+              code, signal
+            )));
+          }
+        });
+      });
     });
   });
 })
 .then(function () {
+  logger.debug('****TEST_LOGGER:[PROCESS_ON_EXIT_SUCCESS]****');
   process.exit(0);
 })
-.catch(function () {
+.catch(function (error) {
+  logger.error(
+    'unexpected error: \'%s\', stack: \'%s\'',
+    error.toString(), error.stack
+  );
+  logger.debug('****TEST_LOGGER:[PROCESS_ON_EXIT_FAILED]****');
   process.exit(1);
 });

--- a/test/www/jxcore/runTests.js
+++ b/test/www/jxcore/runTests.js
@@ -5,12 +5,11 @@ var format = util.format;
 
 var assert       = require('assert');
 var fs           = require('fs-extra-promise');
-var path         = require('path');
 var randomString = require('randomstring');
+var path         = require('path');
 var spawn        = require('child_process').spawn;
 var objectAssign = require('object-assign');
 var Promise      = require('bluebird');
-
 
 // Before including anything serious from thali we want to ensure
 // that we have SSDP_NT env defined.
@@ -21,11 +20,20 @@ if (!process.env.SSDP_NT) {
   });
 }
 
+// This file is special, if it has 'Mobile' enabled
+// we need to enable mobile in any child process.
+if (typeof Mobile === 'undefined') {
+  global.Mobile = require('./lib/wifiBasedNativeMock.js')();
+} else {
+  process.env.isMobileForced = 1;
+}
+
 require('./lib/utils/process.js');
 var testUtils = require('./lib/testUtils');
 var logger    = require('./lib/testLogger')('runTests');
 
 var platform = require('thali/NextGeneration/utils/platform');
+
 
 var DEFAULT_TESTS_DIRECTORY = 'bv_tests';
 
@@ -84,26 +92,62 @@ if (process.argv.length < 3) {
   testFiles = getTestFilesFromPath(process.argv[2]);
 }
 
-var currentPlatform = platform.name;
-// Our current platform can be 'darwin', 'linux', 'windows', etc.
-// Our 'thaliTape' expects all these platforms will be named as 'desktop'.
-if (!platform.isMobile || !currentPlatform) {
-  currentPlatform = 'desktop';
-}
+// We can have here jxcore or node.
+var node = process.env['_'] || 'node';
+var env  = objectAssign({}, process.env);
 
-function instanceLogger () {
-  this.write.apply(this, arguments);
-}
+function runTest (testFile, options) {
+  function instanceLogger () {
+    this.write.apply(this, arguments);
+  }
 
-var nativeUTFailed = global.nativeUTFailed;
-if (nativeUTFailed === undefined || nativeUTFailed === null) {
-  nativeUTFailed = false;
+  return new Promise(function (resolve, reject) {
+    logger.debug('spawning test: \'%s\'', testFile);
+
+    var instance = spawn(
+      node,
+      ['./spawnTest.js', testFile, JSON.stringify(options)],
+      { env: env }
+    );
+
+    instance.stdout
+    .on('data', instanceLogger.bind(process.stdout))
+    .on('error', instanceLogger.bind(process.stderr));
+
+    instance.stderr
+    .on('data', instanceLogger.bind(process.stderr))
+    .on('error', instanceLogger.bind(process.stderr));
+
+    instance.on('exit', function (code, signal) {
+      logger.debug('finished test: \'%s\'', testFile);
+      if (code === 0 && signal === null) {
+        resolve();
+      } else {
+        reject(new Error(format(
+          'test process failed with code: %d, signal: \'%s\'',
+          code, signal
+        )));
+      }
+    });
+  });
 }
 
 testUtils.hasRequiredHardware()
 .then(function (hasRequiredHardware) {
   return testUtils.getOSVersion()
   .then(function (version) {
+    var currentPlatform = platform.name;
+    // Our current platform can be 'darwin', 'linux', 'windows', etc.
+    // Our 'thaliTape' expects all these platforms will be named as 'desktop'.
+    if (!platform.isMobile || !currentPlatform) {
+      currentPlatform = 'desktop';
+    }
+
+    var nativeUTFailed = global.nativeUTFailed;
+    if (nativeUTFailed === undefined || nativeUTFailed === null) {
+      nativeUTFailed = false;
+    }
+
     var options = {
       platform:            currentPlatform,
       version:             version,
@@ -111,39 +155,8 @@ testUtils.hasRequiredHardware()
       nativeUTFailed:      nativeUTFailed
     };
 
-    // We can have here jxcore or node.
-    var node = process.env['_'] || 'node';
-
     return Promise.mapSeries(testFiles, function (testFile) {
-      return new Promise(function (resolve, reject) {
-        logger.debug('spawning test: \'%s\'', testFile);
-
-        var instance = spawn(
-          node,
-          ['./spawnTest.js', testFile, JSON.stringify(options)],
-          objectAssign({}, process.env)
-        );
-
-        instance.stdout
-        .on('data', instanceLogger.bind(process.stdout))
-        .on('error', instanceLogger.bind(process.stderr));
-
-        instance.stderr
-        .on('data', instanceLogger.bind(process.stderr))
-        .on('error', instanceLogger.bind(process.stderr));
-
-        instance.on('exit', function (code, signal) {
-          logger.debug('finished test: \'%s\'', testFile);
-          if (code === 0 && signal === null) {
-            resolve();
-          } else {
-            reject(new Error(format(
-              'test process failed with code: %d, signal: \'%s\'',
-              code, signal
-            )));
-          }
-        });
-      });
+      return runTest(testFile, options);
     });
   });
 })

--- a/test/www/jxcore/spawnTest.js
+++ b/test/www/jxcore/spawnTest.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var assert = require('assert');
+var fs     = require('fs-extra-promise');
+
+var thaliTape = require('./lib/thaliTape');
+
+// The global.Mobile object is replaced here after thaliTape
+// has been required so that thaliTape can pick up the right
+// test framework to be used.
+if (typeof Mobile === 'undefined') {
+  global.Mobile = require('./lib/wifiBasedNativeMock.js')();
+}
+
+
+assert(process.argv.length === 4, 'we should receive 2 arguments: testFile and options');
+
+var testFile = process.argv[2];
+assert(fs.existsSync(testFile), 'test file should exist');
+
+var options  = process.argv[3];
+options = JSON.parse(options);
+assert(options.platform            !== undefined, '\'platform\' should be defined');
+assert(options.version             !== undefined, '\'version\' should be defined');
+assert(options.hasRequiredHardware !== undefined, '\'hasRequiredHardware\' should be defined');
+assert(options.nativeUTFailed      !== undefined, '\'nativeUTFailed\' should be defined');
+
+
+require(testFile);
+thaliTape.begin(options)
+.then(function () {
+  process.exit(0);
+})
+.catch(function (error) {
+  process.exit(1);
+});

--- a/test/www/jxcore/spawnTest.js
+++ b/test/www/jxcore/spawnTest.js
@@ -3,11 +3,12 @@
 var assert = require('assert');
 var fs     = require('fs-extra-promise');
 
+if (process.env.isMobileForced) {
+  global.Mobile = require('./lib/wifiBasedNativeMock.js')();
+}
+
 var thaliTape = require('./lib/thaliTape');
 
-// The global.Mobile object is replaced here after thaliTape
-// has been required so that thaliTape can pick up the right
-// test framework to be used.
 if (typeof Mobile === 'undefined') {
   global.Mobile = require('./lib/wifiBasedNativeMock.js')();
 }
@@ -18,7 +19,7 @@ assert(process.argv.length === 4, 'we should receive 2 arguments: testFile and o
 var testFile = process.argv[2];
 assert(fs.existsSync(testFile), 'test file should exist');
 
-var options  = process.argv[3];
+var options = process.argv[3];
 options = JSON.parse(options);
 assert(options.platform            !== undefined, '\'platform\' should be defined');
 assert(options.version             !== undefined, '\'version\' should be defined');


### PR DESCRIPTION
We have both `require` (old variant) and `spawn` working: `require` for ios (for now) and `spawn` for desktop and android.
Closes #1228.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1279)
<!-- Reviewable:end -->