### PR TITLE
memory leak fix

### DIFF
--- a/lib/ios/ThaliCore/ThaliCore/MultipeerConnectivity/AdvertiserManager.swift
+++ b/lib/ios/ThaliCore/ThaliCore/MultipeerConnectivity/AdvertiserManager.swift
@@ -98,8 +98,10 @@ public final class AdvertiserManager {
                                            Int64(self.disposeTimeout * Double(NSEC_PER_SEC)))
 
         dispatch_after(disposeTimeout, dispatch_get_main_queue()) {
-            [weak self] in
+            [weak self,
+             weak advertiserShouldBeDisposed] in
             guard let strongSelf = self else { return }
+            guard let advertiserShouldBeDisposed = advertiserShouldBeDisposedelse else { return }
 
             strongSelf.advertisers.modify {
                 advertiserShouldBeDisposed.stopAdvertising()

--- a/lib/ios/ThaliCore/ThaliCore/MultipeerConnectivity/AdvertiserManager.swift
+++ b/lib/ios/ThaliCore/ThaliCore/MultipeerConnectivity/AdvertiserManager.swift
@@ -101,7 +101,7 @@ public final class AdvertiserManager {
             [weak self,
              weak advertiserShouldBeDisposed] in
             guard let strongSelf = self else { return }
-            guard let advertiserShouldBeDisposed = advertiserShouldBeDisposedelse else { return }
+            guard let advertiserShouldBeDisposed = advertiserShouldBeDisposed else { return }
 
             strongSelf.advertisers.modify {
                 advertiserShouldBeDisposed.stopAdvertising()


### PR DESCRIPTION
Not a real leak of memory - advertiser will be disposed after 30 sec. But it breaks our logic for `stopAdvertising`. After call of this function all existing advertiser should be stopped and destroyed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1395)
<!-- Reviewable:end -->