### PR TITLE
Use random SSDP_NT for mock

### DIFF
--- a/test/www/jxcore/lib/wifiBasedNativeMock.js
+++ b/test/www/jxcore/lib/wifiBasedNativeMock.js
@@ -65,7 +65,7 @@ proxyquire('thali/NextGeneration/thaliWifiInfrastructure',
       // that the SSDP traffic doesn't get mixed up with real
       // Thali messaging (for example, if in a desktop test,
       // the native and Wifi layers are run simultaneously).
-      SSDP_NT: 'http://www.thaliproject.org/mock'
+      SSDP_NT: (process.env.SSDP_NT || 'http://www.thaliproject.org') + '/mock'
     },
     'ip': {
       address: function () {


### PR DESCRIPTION
This is related to #1072. Mock was not updated to use random SSDP_NT value and native tests could  fail if they had started in the same network simultaneously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1424)
<!-- Reviewable:end -->