### PR TITLE
Enable coordination server to run multiple networkTypes

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -182,6 +182,26 @@ starting the coordinated test from the command line but passing in the parameter
 it runs with the assumption that one will then run `jx UnitTest_app.js` from
 inside an IDE to debug.
 
+By default tests are running with mocked android native API and with WiFi
+network type. It is possible to change it via `--networkType=<wifi|both|native>`
+and `--platform=<ios|android>` parameters, for example:
+
+```
+$ jx runCoordinatedTests.js --platform=ios --networkType=both
+```
+
+Also it is possible to run multiple coordinated tests simultaneously on the same
+machine. Use `COORDINATED_PORT` environment variable to set different port for
+each test runner, for example:
+
+```
+COORDINATED_PORT=12345 jx runCoordinatedTests.js --platform=ios &> ios.log & \
+COORDINATED_PORT=54321 jx runCoordinatedTests.js --platform=android &> android.log &
+```
+
+This example will start iOS tests and android tests in parallel in background
+and write entire output to the ios.log and android.log respectively.
+
 ### Writing Unit Tests
 The Unit Tests are kept in Thali_CordovaPlugin/test/www/jxcore/bv_tests. So please put new tests there.
 

--- a/test/TestServer/index.js
+++ b/test/TestServer/index.js
@@ -13,11 +13,11 @@ var HttpServer        = require('./HttpServer');
 var TestDevice        = require('./TestDevice');
 var UnitTestFramework = require('./UnitTestFramework');
 
-
+var DEFAULT_SERVER_PORT = Number(process.env.COORDINATED_PORT) || 3000;
 var WAITING_FOR_DEVICES_TIMEOUT = 5 * 60 * 1000;
 
 var httpServer = new HttpServer({
-  port: 3000,
+  port: DEFAULT_SERVER_PORT,
   transports: ['websocket']
 });
 

--- a/test/www/jxcore/lib/CoordinatedClient.js
+++ b/test/www/jxcore/lib/CoordinatedClient.js
@@ -19,6 +19,7 @@ var serverAddress = require('../server-address');
 
 var logger = require('./testLogger')('CoordinatedClient');
 
+var DEFAULT_SERVER_PORT = Number(process.env.COORDINATED_PORT) || 3000;
 
 function CoordinatedClient(tests, uuid, platform, version, hasRequiredHardware, nativeUTFailed) {
   asserts.isArray(tests);
@@ -66,7 +67,7 @@ function CoordinatedClient(tests, uuid, platform, version, hasRequiredHardware, 
   this._state = CoordinatedClient.states.created;
 
   this._io = SocketIOClient(
-    'http://' + serverAddress + ':' + 3000 + '/',
+    'http://' + serverAddress + ':' + DEFAULT_SERVER_PORT + '/',
     {
       reconnection: true,
       reconnectionAttempts: 15,

--- a/test/www/jxcore/lib/parsePlatformArg.js
+++ b/test/www/jxcore/lib/parsePlatformArg.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = function () {
+  var platform = require('thali/NextGeneration/utils/platform');
+  var argv = require('minimist')(process.argv.slice(2));
+  if (!argv.platform) {
+    return null;
+  }
+  switch (argv.platform) {
+    case platform.names.IOS:
+    case platform.names.ANDROID:
+      return argv.platform;
+    default:
+      throw new Error('Unrecognized platform: ' + argv.platform + '. ' +
+        'Available platforms: ' + platform.names.join(', '));
+  }
+};

--- a/test/www/jxcore/lib/wifiBasedNativeMock.js
+++ b/test/www/jxcore/lib/wifiBasedNativeMock.js
@@ -1062,6 +1062,8 @@ function WifiBasedNativeMock(platform, router) {
   mobileHandler.wifiPeerAvailabilityChanged =
     wifiPeerAvailabilityChanged(platform, thaliWifiInfrastructure);
 
+  mobileHandler._platform = platform;
+
   return mobileHandler;
 }
 

--- a/test/www/jxcore/runCoordinatedTests.js
+++ b/test/www/jxcore/runCoordinatedTests.js
@@ -1,12 +1,15 @@
 'use strict';
 
-var config       = require('./config.json')
+var config       = require('./config.json');
 var spawn        = require('child_process').spawn;
 var randomString = require('randomstring');
 var objectAssign = require('object-assign');
 
+var platform     = require('thali/NextGeneration/utils/platform');
 
 var DEFAULT_INSTANCE_COUNT = 3;
+var DEFAULT_PLATFORM = platform.names.ANDROID;
+var DEFAULT_NETWORK_TYPE = 'WIFI';
 
 var parseargv = require('minimist');
 var argv = parseargv(process.argv.slice(2), {
@@ -14,6 +17,8 @@ var argv = parseargv(process.argv.slice(2), {
     test: 'UnitTest_app.js',
     filter: null,
     instanceCount: DEFAULT_INSTANCE_COUNT,
+    platform: DEFAULT_PLATFORM,
+    networkType: DEFAULT_NETWORK_TYPE,
     serverLogs: true,
     instanceLogs: true,
     waitForInstance: false,
@@ -132,8 +137,14 @@ var instanceOpts = objectAssign({}, { env: instanceEnv });
 var testInstances = {};
 var spawnTestInstance = function (instanceId) {
   var instanceArgs = [argv.test];
+  if (argv.platform) {
+    instanceArgs.push('--platform=' + argv.platform);
+  }
+  if (argv.networkType) {
+    instanceArgs.push('--networkType=' + argv.networkType);
+  }
   if (argv.filter) {
-    instanceArgs.push(argv.filter);
+    instanceArgs.push('--', argv.filter);
   }
   var testInstance = spawn('jx', instanceArgs, instanceOpts);
   setListeners(testInstance, instanceId);
@@ -144,7 +155,10 @@ for (var i = 1; i <= spawnedInstanceCount; i++) {
   spawnTestInstance(i);
 }
 
+// jshint latedef:false
 var shutdown = function (code) {
+  // jshint latedef:true
+
   // A small delay so that instances have time to print
   // the test results.
   setTimeout(function () {

--- a/test/www/jxcore/runTests.js
+++ b/test/www/jxcore/runTests.js
@@ -23,11 +23,47 @@ var logger    = require('./lib/testLogger')('runTests');
 
 var platform = require('thali/NextGeneration/utils/platform');
 
+var DEFAULT_PLATFORM = platform.names.ANDROID;
+var mockPlatform;
+
+var argv = require('minimist')(process.argv.slice(2), {
+  string: ['platform', 'networkType'],
+  default: {
+    'platform': DEFAULT_PLATFORM
+  }
+});
+
 // The global.Mobile object is replaced here after thaliTape
 // has been required so that thaliTape can pick up the right
 // test framework to be used.
 if (typeof Mobile === 'undefined') {
-  global.Mobile = require('./lib/wifiBasedNativeMock.js')();
+  mockPlatform = require('./lib/parsePlatformArg')() || DEFAULT_PLATFORM;
+  global.Mobile = require('./lib/wifiBasedNativeMock.js')(mockPlatform);
+} else {
+  mockPlatform = Mobile._platform; // mock may be created in UnitTest_app.js
+}
+
+var networkTypes = require('thali/NextGeneration/thaliMobile').networkTypes;
+
+if (argv.networkType) {
+  var networkType = argv.networkType.toUpperCase();
+  switch (networkType) {
+    case networkTypes.WIFI:
+    case networkTypes.NATIVE:
+    case networkTypes.BOTH:
+      global.NETWORK_TYPE = networkType;
+      break;
+    default:
+      logger.warn(
+        'Unrecognized network type: ' + networkType + '. ' +
+        'Available network types: ' + [
+          networkTypes.WIFI,
+          networkTypes.NATIVE,
+          networkTypes.BOTH,
+        ].join(', ')
+      );
+      process.exit(1);
+  }
 }
 
 var hasJavaScriptSuffix = function (path) {
@@ -48,7 +84,20 @@ var loadFile = function (filePath) {
   }
 };
 
-var testsToRun = process.argv.length > 2 ? process.argv[2] : 'bv_tests';
+var testsToRun = argv._[0] || 'bv_tests';
+
+var currentPlatform = platform.name;
+// Our current platform can be 'darwin', 'linux', 'windows', etc.
+// Our 'thaliTape' expects all these platforms will be named as 'desktop'.
+if (!platform.isMobile) {
+  currentPlatform = 'desktop';
+}
+
+logger.info(
+  'Starting tests. ' +
+  'Network type: ' + global.NETWORK_TYPE + '. ' +
+  'Platform: ' + (mockPlatform || currentPlatform)
+);
 
 if (hasJavaScriptSuffix(testsToRun)) {
   loadFile(path.join(__dirname, testsToRun));
@@ -60,13 +109,6 @@ if (hasJavaScriptSuffix(testsToRun)) {
       loadFile(filePath);
     }
   });
-}
-
-var currentPlatform = platform.name;
-// Our current platform can be 'darwin', 'linux', 'windows', etc.
-// Our 'thaliTape' expects all these platforms will be named as 'desktop'.
-if (!platform.isMobile) {
-  currentPlatform = 'desktop';
 }
 
 testUtils.hasRequiredHardware()


### PR DESCRIPTION
Closes #1172.

I have to admit it is very ugly solution. Partially because we have multiple entry points for running tests (there is `jx runCoordinated.js`, `jx runTests.js`, and `jx UnitTest_app.js` which are depend on each other) and side effects in the core modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1430)
<!-- Reviewable:end -->