### PR TITLE
Added PouchDB agent test

### DIFF
--- a/test/www/jxcore/lib/testUtils.js
+++ b/test/www/jxcore/lib/testUtils.js
@@ -692,7 +692,7 @@ var createPskPouchDBRemote = function (
   // See the notes in thaliReplicationPeerAction.start for why the below
   // is here and why it's wrong and should use agent instead but can't.
   return new getLevelDownPouchDb()(
-      serverUrl, {
+    serverUrl, {
       ajax: {
         agent: new ForeverAgent.SSL({
           keepAlive: true,

--- a/test/www/jxcore/lib/testUtils.js
+++ b/test/www/jxcore/lib/testUtils.js
@@ -692,19 +692,17 @@ var createPskPouchDBRemote = function (
   // See the notes in thaliReplicationPeerAction.start for why the below
   // is here and why it's wrong and should use agent instead but can't.
   return new getLevelDownPouchDb()(
-    serverUrl, {
+      serverUrl, {
       ajax: {
-        agentClass: ForeverAgent.SSL,
-        agentOptions: {
+        agent: new ForeverAgent.SSL({
           keepAlive: true,
           keepAliveMsecs: thaliConfig.TCP_TIMEOUT_WIFI/2,
           maxSockets: Infinity,
           maxFreeSockets: 256,
           ciphers: thaliConfig.SUPPORTED_PSK_CIPHERS,
           pskIdentity: pskId,
-          pskKey: pskKey,
-          secureOptions: pskId + serverUrl
-        }
+          pskKey: pskKey
+        })
       }
     }
   );

--- a/test/www/jxcore/meta_tests/testPouchDBAgent.js
+++ b/test/www/jxcore/meta_tests/testPouchDBAgent.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Promise        = require('bluebird');
+var objectAssign   = require('object-assign');
 var ForeverAgent   = require('forever-agent');
 var express        = require('express');
 var expressPouchDB = require('express-pouchdb');
@@ -20,8 +22,15 @@ var test = tape({
   }
 });
 
-test('a', function (t) {
+test('PouchDB agent works as expected', function (t) {
   var agent = new ForeverAgent();
+
+  var requestsData = [];
+  var _addRequest = agent.addRequest;
+  agent.addRequest = function (data) {
+    requestsData.push(objectAssign({}, data));
+    return _addRequest.apply(this, arguments);
+  }
 
   var app = express();
   app.use('/db', expressPouchDB(PouchDB));
@@ -29,21 +38,35 @@ test('a', function (t) {
   var server = http.createServer(app);
   server.listen(0, function () {
     var port  = server.address().port;
-    var url   = 'http://localhost:' + port + '/db/fit';
+    var url   = 'http://localhost:' + port + '/db';
     var db    = new PouchDB(url , {
       ajax: {
         agent: agent
       }
     });
-    console.log(db.__opts.ajax.agent === agent);
-    db.get('fit')
+
+    function query(name) {
+      return db.get(name)
+        .then(function () {
+          t.fail('we should not find a document');
+        })
+        .catch(function (error) {
+          t.ok(error, 'error is not empty');
+          t.equals(error.status, 404, 'status should be 404');
+        })
+        .then(function () {
+          var lastData = requestsData[requestsData.length - 1];
+          t.equals(lastData.method, 'GET', 'method is \'get\'');
+          t.equals(lastData.path, '/db/' + name + '?', 'path is ok');
+        });
+    }
+
+    query('fit')
       .then(function () {
-        t.pass('ok');
-        t.end();
+        return query('foo');
       })
-      .catch(function (error) {
-        console.error('got error', error);
-        t.fail('got error' + error);
+      .then(function () {
+        t.ok(requestsData.length > 2, 'we should call agent more than twice');
         t.end();
       });
   });

--- a/test/www/jxcore/meta_tests/testPouchDBAgent.js
+++ b/test/www/jxcore/meta_tests/testPouchDBAgent.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var ForeverAgent   = require('forever-agent');
+var express        = require('express');
+var expressPouchDB = require('express-pouchdb');
+var http           = require('http');
+
+var tape      = require('../lib/thaliTape');
+var testUtils = require('../lib/testUtils');
+
+var PouchDB = testUtils.getLevelDownPouchDb();
+
+
+var test = tape({
+  setup: function (t) {
+    t.end();
+  },
+  teardown: function (t) {
+    t.end();
+  }
+});
+
+test('a', function (t) {
+  var agent = new ForeverAgent();
+
+  var app = express();
+  app.use('/db', expressPouchDB(PouchDB));
+
+  var server = http.createServer(app);
+  server.listen(0, function () {
+    var port  = server.address().port;
+    var url   = 'http://localhost:' + port + '/db/fit';
+    var db    = new PouchDB(url , {
+      ajax: {
+        agent: agent
+      }
+    });
+    console.log(db.__opts.ajax.agent === agent);
+    db.get('fit')
+      .then(function () {
+        t.pass('ok');
+        t.end();
+      })
+      .catch(function (error) {
+        console.error('got error', error);
+        t.fail('got error' + error);
+        t.end();
+      });
+  });
+});

--- a/thali/NextGeneration/replication/thaliReplicationPeerAction.js
+++ b/thali/NextGeneration/replication/thaliReplicationPeerAction.js
@@ -223,16 +223,7 @@ ThaliReplicationPeerAction.prototype.start = function (httpAgentPool) {
         ':' + self._peerAdvertisesDataForUs.portNumber + path.join(thaliConfig.BASE_DB_PATH, self._dbName);
       var ajaxOptions = {
         ajax : {
-          agent: new ForeverAgent.SSL({
-            rejectUnauthorized: false,
-            keepAlive: true,
-            keepAliveMsecs: thaliConfig.TCP_TIMEOUT_WIFI/2,
-            maxSockets: Infinity,
-            maxFreeSockets: 256,
-            ciphers: thaliConfig.SUPPORTED_PSK_CIPHERS,
-            pskIdentity: self.getPskIdentity(),
-            pskKey: self.getPskKey()
-          })
+          agent: httpAgentPool
         },
         skip_setup: true// jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
       };

--- a/thali/NextGeneration/replication/thaliReplicationPeerAction.js
+++ b/thali/NextGeneration/replication/thaliReplicationPeerAction.js
@@ -223,8 +223,7 @@ ThaliReplicationPeerAction.prototype.start = function (httpAgentPool) {
         ':' + self._peerAdvertisesDataForUs.portNumber + path.join(thaliConfig.BASE_DB_PATH, self._dbName);
       var ajaxOptions = {
         ajax : {
-          agentClass: ForeverAgent.SSL,
-          agentOptions : {
+          agent: new ForeverAgent.SSL({
             rejectUnauthorized: false,
             keepAlive: true,
             keepAliveMsecs: thaliConfig.TCP_TIMEOUT_WIFI/2,
@@ -232,9 +231,8 @@ ThaliReplicationPeerAction.prototype.start = function (httpAgentPool) {
             maxFreeSockets: 256,
             ciphers: thaliConfig.SUPPORTED_PSK_CIPHERS,
             pskIdentity: self.getPskIdentity(),
-            pskKey: self.getPskKey(),
-            secureOptions: self.getPskIdentity() + remoteUrl
-          }
+            pskKey: self.getPskKey()
+          })
         },
         skip_setup: true// jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
       };


### PR DESCRIPTION
Closes #730.

Our pouch `5.4.5` is fine. It has some kind of `isPlainObject` and this function bypasses our agent.

@chapko found a [commit](https://github.com/pouchdb/pouchdb/commit/a3736c7d455b5a0133fc594a395e1800d90ac010), it adds this function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1466)
<!-- Reviewable:end -->
