### PR TITLE
#1588 Fixing up Android buffer problem and failing tests

### DIFF
--- a/src/android/java/io/jxcore/node/OutgoingSocketThread.java
+++ b/src/android/java/io/jxcore/node/OutgoingSocketThread.java
@@ -2,12 +2,10 @@
  * See the license file delivered with this project for further information.
  */
 package io.jxcore.node;
-import android.os.Build;
 import android.bluetooth.BluetoothSocket;
 import android.util.Log;
 import org.thaliproject.p2p.btconnectorlib.PeerProperties;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
@@ -65,10 +63,7 @@ class OutgoingSocketThread extends SocketThreadBase {
         mIsClosing = false;
 
         try {
-            mServerSocket = new ServerSocket();
-            InetSocketAddress addr = new InetSocketAddress(0);
-            mServerSocket.setReceiveBufferSize(receiveBufferSize);
-            mServerSocket.bind(addr);
+            mServerSocket = new ServerSocket(0);
             Log.d(mTag, "Server socket local port: " + mServerSocket.getLocalPort());
         } catch (IOException e) {
             Log.e(mTag, "Failed to create a server socket instance: " + e.getMessage(), e);
@@ -89,7 +84,6 @@ class OutgoingSocketThread extends SocketThreadBase {
                     mListener.onListeningForIncomingConnections(mListeningOnPortNumber);
                 }
                 mLocalhostSocket = mServerSocket.accept(); // Blocking call
-                configureSocket();
                 Log.i(mTag, "Incoming data from address: " + getLocalHostAddressAsString()
                     + ", port: " + mServerSocket.getLocalPort());
 

--- a/src/android/java/io/jxcore/node/SocketThreadBase.java
+++ b/src/android/java/io/jxcore/node/SocketThreadBase.java
@@ -39,10 +39,7 @@ abstract class SocketThreadBase extends Thread implements StreamCopyingThread.Li
 
     private static final String SENDING_THREAD_NAME = "Sender";
     private static final String RECEIVING_THREAD_NAME = "Receiver";
-    protected static final int STREAM_COPYING_THREAD_BUFFER_SIZE = 1024 * 8;
-
-    protected int receiveBufferSize = STREAM_COPYING_THREAD_BUFFER_SIZE;
-    protected int sendBufferSize = STREAM_COPYING_THREAD_BUFFER_SIZE;
+    protected static final int STREAM_COPYING_THREAD_BUFFER_SIZE = 1024 * 4;
 
     protected final BluetoothSocket mBluetoothSocket;
     protected final Listener mListener;
@@ -270,12 +267,12 @@ abstract class SocketThreadBase extends Thread implements StreamCopyingThread.Li
 
             mSendingThread = new StreamCopyingThread(this, mLocalInputStream, mBluetoothOutputStream, shortName + "/" + SENDING_THREAD_NAME, connectionData);
             mSendingThread.setUncaughtExceptionHandler(this.getUncaughtExceptionHandler());
-            mSendingThread.setBufferSize(sendBufferSize);
+            mSendingThread.setBufferSize(STREAM_COPYING_THREAD_BUFFER_SIZE);
             mSendingThread.setNotifyStreamCopyingProgress(true);
             mSendingThread.start();
             mReceivingThread = new StreamCopyingThread(this, mBluetoothInputStream, mLocalOutputStream, shortName + "/" + RECEIVING_THREAD_NAME, connectionData);
             mReceivingThread.setUncaughtExceptionHandler(this.getUncaughtExceptionHandler());
-            mReceivingThread.setBufferSize(receiveBufferSize);
+            mReceivingThread.setBufferSize(STREAM_COPYING_THREAD_BUFFER_SIZE);
             mReceivingThread.setNotifyStreamCopyingProgress(true);
             mReceivingThread.start();
 
@@ -286,11 +283,8 @@ abstract class SocketThreadBase extends Thread implements StreamCopyingThread.Li
     protected void configureSocket() throws SocketException {
         if(mLocalhostSocket!=null){
             mLocalhostSocket.setKeepAlive(true);
-            mLocalhostSocket.setReceiveBufferSize(receiveBufferSize);
-            mLocalhostSocket.setSendBufferSize(sendBufferSize);
             mLocalhostSocket.setReuseAddress(false);
             mLocalhostSocket.setOOBInline(false);
-            mLocalhostSocket.setSoLinger(true , 0);
             mLocalhostSocket.setSoTimeout(0);
             mLocalhostSocket.setTcpNoDelay(true);
         }

--- a/src/android/java/io/jxcore/node/SocketThreadBase.java
+++ b/src/android/java/io/jxcore/node/SocketThreadBase.java
@@ -84,17 +84,7 @@ abstract class SocketThreadBase extends Thread implements StreamCopyingThread.Li
         mBluetoothOutputStream = outputStream;
         mListener = listener;
         mBluetoothSocket = bluetoothSocket;
-        setBufferSizes();
     }
-
-    private void setBufferSizes(){
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && mBluetoothSocket!=null) {
-            receiveBufferSize = mBluetoothSocket.getMaxReceivePacketSize();
-            sendBufferSize = mBluetoothSocket.getMaxTransmitPacketSize();
-        }
-    }
-
-
 
     public Listener getListener() {
         return mListener;

--- a/test/www/jxcore/bv_tests/testThaliMobileNative.js
+++ b/test/www/jxcore/bv_tests/testThaliMobileNative.js
@@ -187,7 +187,13 @@ function getMessageByLength(socket, lengthOfMessage) {
 function getMessageAndThen(t, socket, messageToReceive, cb) {
   return getMessageByLength(socket, messageToReceive.length)
     .then(function (data) {
-      t.ok(Buffer.compare(messageToReceive, data) === 0, 'Data matches');
+      // This method can be called from a server where other peers are still
+      // sending us requests even though we are done. But if we call 't' after
+      // calling t.end then we get an unexpected event error. So we won't call
+      // t unless there is a problem.
+      if (Buffer.compare(messageToReceive, data) !== 0) {
+        t.fail('Data does not match');
+      }
       return cb();
     })
     .catch(function (err) {

--- a/test/www/jxcore/bv_tests/testThaliMobileNativeWrapper.js
+++ b/test/www/jxcore/bv_tests/testThaliMobileNativeWrapper.js
@@ -445,92 +445,98 @@ test('We repeat failedConnection event when we get it from ' +
 
 test('can do HTTP requests between peers without coordinator',
   function() {
-    return platform.isMobile;
-  }, function (t) {
-  trivialEndToEndTest(t, true);
-});
+    return platform._isRealMobile;
+  },
+  function (t) {
+    trivialEndToEndTest(t, true);
+  });
 
 test('make sure bad PSK connections fail',
   function () {
-    return platform.isMobile;
-  }, function (t) {
-  //trivialBadEndtoEndTest(t, true);
-  // TODO: Re-enable and fix
-  t.ok(true, 'FIX ME, PLEASE!!!');
-  t.end();
-});
+    // #1587
+    // return platform._isRealMobile;
+    return true;
+  },
+  function (t) {
+    //trivialBadEndtoEndTest(t, true);
+    // TODO: Re-enable and fix
+    t.ok(true, 'FIX ME, PLEASE!!!');
+    t.end();
+  });
 
 test('peer changes handled from a queue',
   function () {
-    return platform.isMobile;
-  }, function (t) {
-  thaliMobileNativeWrapper.start(express.Router())
-    .then(function () {
-      var peerAvailabilityHandler;
-      var peerCount = 10;
-      var getDummyPeers = function (peerAvailable) {
-        var dummyPeers = [];
-        for (var i = 1; i <= peerCount; i++) {
-          dummyPeers.push({
-            peerIdentifier: i + '',
-            peerAvailable: peerAvailable
-          });
-        }
-        return dummyPeers;
-      };
-      var endTest = function () {
-        thaliMobileNativeWrapper.emitter.removeListener(
-          'nonTCPPeerAvailabilityChangedEvent',
+    return platform._isRealMobile;
+  },
+  function (t) {
+    thaliMobileNativeWrapper.start(express.Router())
+      .then(function () {
+        var peerAvailabilityHandler;
+        var peerCount = 10;
+        var getDummyPeers = function (peerAvailable) {
+          var dummyPeers = [];
+          for (var i = 1; i <= peerCount; i++) {
+            dummyPeers.push({
+              peerIdentifier: i + '',
+              peerAvailable: peerAvailable
+            });
+          }
+          return dummyPeers;
+        };
+        var endTest = function () {
+          thaliMobileNativeWrapper.emitter.removeListener(
+            'nonTCPPeerAvailabilityChangedEvent',
+            peerAvailabilityHandler);
+          Mobile.firePeerAvailabilityChanged(getDummyPeers(false));
+          t.end();
+        };
+        var previousPeerNumber = 0;
+        peerAvailabilityHandler = function (peer) {
+          var peerNumber = parseInt(peer.peerIdentifier);
+          if (peerNumber - 1 !== previousPeerNumber) {
+            t.fail('peers should be handled in order');
+            endTest();
+          }
+          previousPeerNumber = peerNumber;
+          if (peerNumber === peerCount) {
+            t.ok(true, 'peers were handled in the right order');
+            endTest();
+          }
+        };
+        thaliMobileNativeWrapper.emitter.on('nonTCPPeerAvailabilityChangedEvent',
           peerAvailabilityHandler);
-        Mobile.firePeerAvailabilityChanged(getDummyPeers(false));
-        t.end();
-      };
-      var previousPeerNumber = 0;
-      peerAvailabilityHandler = function (peer) {
-        var peerNumber = parseInt(peer.peerIdentifier);
-        if (peerNumber - 1 !== previousPeerNumber) {
-          t.fail('peers should be handled in order');
-          endTest();
-        }
-        previousPeerNumber = peerNumber;
-        if (peerNumber === peerCount) {
-          t.ok(true, 'peers were handled in the right order');
-          endTest();
-        }
-      };
-      thaliMobileNativeWrapper.emitter.on('nonTCPPeerAvailabilityChangedEvent',
-        peerAvailabilityHandler);
-      Mobile.firePeerAvailabilityChanged(getDummyPeers(true));
-    });
-});
+        Mobile.firePeerAvailabilityChanged(getDummyPeers(true));
+      });
+  });
 
 test('relaying discoveryAdvertisingStateUpdateNonTCP',
   function() {
-    return platform.isMobile;
-  }, function (t) {
-  thaliMobileNativeWrapper.start(express.Router())
-    .then(function () {
-      thaliMobileNativeWrapper.emitter.once(
-        'discoveryAdvertisingStateUpdateNonTCP',
-        function (discoveryAdvertisingStateUpdateValue) {
-          t.ok(discoveryAdvertisingStateUpdateValue.discoveryActive,
-            'discovery is active');
-          t.ok(discoveryAdvertisingStateUpdateValue.advertisingActive,
-            'advertising is active');
-          t.end();
-        }
-      );
-      Mobile.fireDiscoveryAdvertisingStateUpdateNonTCP({
-        discoveryActive: true,
-        advertisingActive: true
+    return platform._isRealMobile;
+  },
+  function (t) {
+    thaliMobileNativeWrapper.start(express.Router())
+      .then(function () {
+        thaliMobileNativeWrapper.emitter.once(
+          'discoveryAdvertisingStateUpdateNonTCP',
+          function (discoveryAdvertisingStateUpdateValue) {
+            t.ok(discoveryAdvertisingStateUpdateValue.discoveryActive,
+              'discovery is active');
+            t.ok(discoveryAdvertisingStateUpdateValue.advertisingActive,
+              'advertising is active');
+            t.end();
+          }
+        );
+        Mobile.fireDiscoveryAdvertisingStateUpdateNonTCP({
+          discoveryActive: true,
+          advertisingActive: true
+        });
       });
-    });
-});
+  });
 
 test('thaliMobileNativeWrapper is stopped when ' +
   'incomingConnectionToPortNumberFailed is received',
   function () {
-    return platform.isMobile;
+    return platform._isRealMobile;
   },
   function (t) {
     var routerPort = 0;
@@ -552,8 +558,7 @@ test('thaliMobileNativeWrapper is stopped when ' +
       .then(function () {
         Mobile.fireIncomingConnectionToPortNumberFailed(routerPort);
       });
-  }
-);
+  });
 
 test('we successfully receive and replay discoveryAdvertisingStateUpdate',
   function (t) {

--- a/test/www/jxcore/lib/CoordinatedClient.js
+++ b/test/www/jxcore/lib/CoordinatedClient.js
@@ -398,7 +398,8 @@ CoordinatedClient.prototype._skipEvent = function (tape, test, event, timeout) {
     );
 }
 
-CoordinatedClient.prototype._processEvent = function (tape, test, event, fun, timeout) {
+CoordinatedClient.prototype._processEvent = function (tape, test, event, fun,
+                                                      timeout) {
   var self = this;
 
   return this._runEvent(event, test)
@@ -568,10 +569,10 @@ CoordinatedClient.prototype.unexpectedResult = function (result) {
     error = result.error;
   }
   logger.error(
-    'unexpected result, error: \'%s\', stack: \'%s\'',
-    String(error), error ? error.stack : null
+    'unexpected result, error: \'%s\', stack: \'%s\', original result: \'%s\'',
+    String(error), error ? error.stack : null, JSON.stringify(result)
   );
   this.emit('unexpected_error', error);
-}
+};
 
 module.exports = CoordinatedClient;

--- a/thali/NextGeneration/makeIntoCloseAllServer.js
+++ b/thali/NextGeneration/makeIntoCloseAllServer.js
@@ -57,7 +57,7 @@ function makeIntoCloseAllServer(server, eatNotRunning) {
     // are destroyed because the destroy calls are synchronous.
     try {
       server.close(callback);
-    } catch(err){
+    } catch (err){
       if (!eatNotRunning || !(err instanceof Error) ||
         (err && err.message !== 'Not running')) {
         throw err;


### PR DESCRIPTION
SocketThreadBase - Turns out that the logic that got checked in could end up setting buffers to zero
because the Bluetooth socket get size calls could return 0. For now I decided to just remove the dynamic
size setting to simplify things. This should hopefully fix Android.

testThaliMobileNative - We have a condition where we could test something after we have called t.end but
this is necessary because our peer might be done with the test but the other might not. So now the test
will only cause a failure if it actually fails in which case we should fail.

testThaliMobileNativeWrapper - In addition to an identical issue to the one described above we also had tests
that were written before the skip functionality so I fixed that. Also some of the test names were so similar it
made doing searches hard so I added some text to make them different.

CoordinatedClient - Added the original result object to the error

makeIntoCloseAllServer - Linting

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1589)
<!-- Reviewable:end -->