### PR TITLE
#1632 - Fixing broken build

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -51,10 +51,10 @@ In terms of operating system we assume you are running on macOS. In theory we ca
 run successfully on Linux or Windows but we really don't test there very often
 so things are likely to break.
 
-From there you need to install in macOS a fairly large mountain of software. For
-now you can see the list [here](https://github.com/thaliproject/Thali_CordovaPlugin/blob/1df36b74ee93f1ece85579857ed90a0e05a0cdd1/thali/install/validateBuildEnvironment.js#L16).
-You need to install the listed software at the listed version. Two of the entries
-are about Sinopia. Details on that is in the next section.
+From there you need to install in macOS a fairly large mountain of software. We
+ have a script, validateBuildEnvironment.js, that checks for all the required
+ software. You need to install all that software at the listed version for the
+ build to work. Two of the entries are about Sinopia. Details on that is in the next section.
 
 ### Running your own NPM registry
 From time to time we run into bugs in PouchDB and Express-PouchDB that we can't

--- a/thali/install/install.js
+++ b/thali/install/install.js
@@ -306,9 +306,9 @@ function generateGradlePropertiesFile(thaliDepotName, thaliBranchName,
     projectDir, 'src', 'android', 'gradle.properties');
   var fileContents = util.format(
     'btconnectorlib2Version = %s\n' +
-    'ext.cdvMinSdkVersion = %s\n' +
-    'ext.cdvBuildToolsVersion = %s\n' +
-    'ext.cdvCompileSdkVersion = %s\n',
+    'cdvMinSdkVersion = %s\n' +
+    'cdvBuildToolsVersion = %s\n' +
+    'cdvCompileSdkVersion = %s\n',
     releaseConf.btconnectorlib2,
     releaseConf.androidConfig.minSdkVersion,
     releaseConf.androidConfig.buildToolsVersion,

--- a/thali/install/setUpDesktop.sh
+++ b/thali/install/setUpDesktop.sh
@@ -12,7 +12,7 @@ trap 'log_error $LINENO' ERR
 
 # These variables are set since a bug in jxcore
 # `jx npm install` and `jx install` have different behaviours
-NVM_NODEJS_ORG_MIRROR="${NVM_NODEJS_ORG_MIRROR-https://jxcore.azureedge.net}"
+NVM_NODEJS_ORG_MIRROR=https://jxcore.azureedge.net
 export NVM_NODEJS_ORG_MIRROR
 JX_NPM_JXB="${JX_NPM_JXB-jxb311}"
 export JX_NPM_JXB


### PR DESCRIPTION
README - Updating to the actual validateBuildEnvironment script that we now run

install - Turns out I used the syntax for build-extras.gradle instead of gradle.properties and didn't realize it because I still had the environment variables defined.

setUpDesktop - The logic we were using which would use the global variable if already defined otherwise it would set it doesn't work in the case of NVM_NODEJS_ORG_MIRROR if someone is using NVM which also sets this variable. Since NVM is more common than needing to change this location when doing our build I decided to revert that change and just overwrite the variable when we are doing a build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1636)
<!-- Reviewable:end -->
