### PR TITLE
Fix "module not found" error during build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-### START - JXcore Test Server --------......................
+### START - JXcore Test Server --------.......................
 ### Testing environment prepares separate packages for each node.
 ### Package builder calls this script with each node's IP address
 ### Make sure multiple calls to this script file compiles the application file

--- a/test/www/jxcore/installCustomPouchDB.js
+++ b/test/www/jxcore/installCustomPouchDB.js
@@ -4,7 +4,6 @@ var exec = require('child_process').exec;
 var path = require('path');
 var http = require('http');
 var fs = require('fs'); // Will be overwritten by fs-extra-promise
-var objectAssign = require('object-assign');
 var Promise = null; // Wil be set below
 
 var pouchDBNodePackageName = 'pouchdb';
@@ -40,7 +39,7 @@ function childProcessExecPromise(commandString, currentWorkingDirectory, env) {
   return new Promise(function (resolve, reject) {
     var commandSplit = commandString.split(' ');
     var command = commandSplit.shift();
-    env = objectAssign({}, process.env, env);
+    env = Object.assign({}, process.env, env);
     var theProcess = spawn(command, commandSplit,
       { cwd: currentWorkingDirectory, env: env });
     theProcess.stdout.on('data', function (data) {


### PR DESCRIPTION
setUpDesktop.sh runs `node installCustomPouchDB.js` before dependencies
are installed. Since we are using pure node we can just drop
object-assign dependency and use native implementation