### PR TITLE
Fix for 'test for data corruption'

### DIFF
--- a/test/www/jxcore/bv_tests/testThaliMobile.js
+++ b/test/www/jxcore/bv_tests/testThaliMobile.js
@@ -34,8 +34,10 @@ var test = tape({
       t.end();
     });
   },
-  // Extend test and teardown timeouts. Sometimes it takes quite
-  // long to establish bluetooth connection.
+
+  // These time outs are excessive because of issues we are having
+  // with Bluetooth, see #1569. When #1569 is fixed we will be able
+  // to reduce these time outs to a reasonable level.
   testTimeout:      5 * 60 * 1000,
   teardownTimeout:  5 * 60 * 1000
 });
@@ -2247,6 +2249,7 @@ test('test for data corruption',
     // Timer is used because of possible race condition when stopping and starting
     // ThaliMobile every time error occurs, which led to test failure because exception was
     // thrown.
+    // This issue is tracked in #1719.
     var timer = setInterval(function() {
       logger.debug('Restarting test for data corruption');
 

--- a/test/www/jxcore/bv_tests/testThaliMobile.js
+++ b/test/www/jxcore/bv_tests/testThaliMobile.js
@@ -33,7 +33,11 @@ var test = tape({
       verifyCombinedResultSuccess(t, combinedResult);
       t.end();
     });
-  }
+  },
+  // Extend test and teardown timeouts. Sometimes it takes quite
+  // long to establish bluetooth connection.
+  testTimeout:      5 * 60 * 1000,
+  teardownTimeout:  5 * 60 * 1000
 });
 
 var testIdempotentFunction = function (t, functionName) {
@@ -2228,8 +2232,8 @@ function setUpRouter() {
 
 test('test for data corruption',
   function () {
-    // Bug 1594
-    return true;
+    return global.NETWORK_TYPE === ThaliMobile.networkTypes.WIFI
+      || !platform.isAndroid;
   },
   function (t) {
     var router = setUpRouter();
@@ -2237,26 +2241,57 @@ test('test for data corruption',
     var peerIDToUUIDMap = {};
     var areWeDone = false;
     var promiseQueue = new PromiseQueue();
-    t.participants.forEach(function (participant) {
-      if (participant.uuid === tape.uuid) {
-        return;
-      }
-      participantsState[participant.uuid] = participantState.notRunning;
-    });
-    setupDiscoveryAndFindPeers(t, router, function (peer, done) {
+
+    // This timer purpose is to manually restart ThaliMobile every 60 seconds.
+    // Whole test timeout is set to 5 minutes, so there will be at most 4 restart attempts.
+    // Timer is used because of possible race condition when stopping and starting
+    // ThaliMobile every time error occurs, which led to test failure because exception was
+    // thrown.
+    var timer = setInterval(function() {
+      logger.debug('Restarting test for data corruption');
+
+      ThaliMobile.stop().then(function() {
+        runTestFunction();
+      });
+    }, 60 * 1000);
+
+    var runTestFunction = function () {
+      t.participants.forEach(function (participant) {
+        if (participant.uuid === tape.uuid) {
+          return;
+        }
+        participantsState[participant.uuid] = participantState.notRunning;
+      });
+
+      setupDiscoveryAndFindPeers(t, router, function (peer, done) {
+        testFunction(peer).then(function (result) {
+          // Check if promise was resolved with true.
+          if (result) {
+            t.ok(true, 'Test for data corruption succeed');
+            done();
+            clearInterval(timer);
+          }
+        })
+      });
+    };
+
+    var testFunction = function (peer) {
       // Try to get data only from non-TCP peers so that the test
       // works the same way on desktop on CI where Wifi is blocked
       // between peers.
       if (peer.connectionType ===
         ThaliMobileNativeWrapper.connectionTypes.TCP_NATIVE) {
-        return;
+        Promise.resolve(true);
       }
+
       if (peerIDToUUIDMap[peer.peerIdentifier] &&
-          participantsState[peerIDToUUIDMap[peer.peerIdentifier] ===
-            participantState.finished]) {
-        return;
+        participantsState[peerIDToUUIDMap[peer.peerIdentifier] ===
+        participantState.finished]) {
+        Promise.resolve(true);
       }
-      promiseQueue.enqueue(function (resolve) {
+      return promiseQueue.enqueue(function (resolve) {
+        // To avoid multiple t.end() calls, just resolve here with null.
+        // The areWeDone check will be called anyway in different section.
         if (areWeDone) {
           return resolve(null);
         }
@@ -2268,69 +2303,67 @@ test('test for data corruption',
         var portNumber = null;
 
         ThaliMobile.getPeerHostInfo(peer.peerIdentifier, peer.connectionType)
-        .then(function (peerHostInfo) {
-          hostAddress = peerHostInfo.hostAddress;
-          portNumber = peerHostInfo.portNumber;
+          .then(function (peerHostInfo) {
+            hostAddress = peerHostInfo.hostAddress;
+            portNumber = peerHostInfo.portNumber;
 
-          return testUtils.get(
-            hostAddress, portNumber,
-            uuidPath, pskIdentity, pskKey
-          );
-        })
-        .then(function (responseBody) {
-          uuid = responseBody;
-          peerIDToUUIDMap[peer.peerIdentifier] = uuid;
-          logger.debug('Got uuid back from GET - ' + uuid);
-          if (participantsState[uuid] !== participantState.notRunning) {
-            logger.debug('Participant is already done - ' + uuid);
-            return false;
-          } else {
-            logger.debug('Participants state is ' + participantsState[uuid]);
-          }
+            return testUtils.get(
+              hostAddress, portNumber,
+              uuidPath, pskIdentity, pskKey
+            );
+          })
+          .then(function (responseBody) {
+            uuid = responseBody;
+            peerIDToUUIDMap[peer.peerIdentifier] = uuid;
+            logger.debug('Got uuid back from GET - ' + uuid);
 
-          participantsState[uuid] = participantState.running;
+            if (participantsState[uuid] !== participantState.notRunning) {
+              logger.debug('Participant is already done - ' + uuid);
+              return resolve(null);
+            } else {
+              logger.debug('Participants state is ' + participantsState[uuid]);
+            }
 
-          return numberOfParallelRequests(t, hostAddress, portNumber,
-            echoPath, pskIdentity, pskKey)
+            participantsState[uuid] = participantState.running;
+
+            return numberOfParallelRequests(t, hostAddress, portNumber,
+              echoPath, pskIdentity, pskKey)
+              .then(function () {
+                logger.debug('Got back from parallel requests - ' + uuid);
+                participantsState[uuid] = participantState.finished;
+              });
+          })
+          .catch(function (error) {
+            logger.debug('Got an error on HTTP requests: ' + error);
+          })
           .then(function () {
-            logger.debug('Got back from parallel requests - ' + uuid);
-            participantsState[uuid] = participantState.finished;
             areWeDone = Object.getOwnPropertyNames(participantsState)
               .every(
                 function (participant) {
-                  return participantsState[participant] ===
-                    participantState.finished;
+                  return participantsState[participant] ===  participantState.finished
                 });
+
             if (areWeDone) {
-              t.ok(true, 'received all uuids');
-              done();
+              logger.debug('received all uuids');
+
+              return resolve(true);
             }
-            return false;
+
+            ThaliMobileNativeWrapper._getServersManager()
+              .terminateOutgoingConnection(peer.peerIdentifier, peer.portNumber);
+
+            // We have to give Android enough time to notice the killed connection
+            // and recycle everything
+            setTimeout(function () {
+              return resolve(null);
+            }, 1000);
           });
-        })
-        .catch(function (error) {
-          logger.debug('Got an error on HTTP requests: ' + error);
-          return true;
-        })
-        .then(function (isError) {
-          if (areWeDone) {
-            return resolve(null);
-          }
-          ThaliMobileNativeWrapper._getServersManager()
-            .terminateOutgoingConnection(peer.peerIdentifier, peer.portNumber);
-          // We have to give Android enough time to notice the killed connection
-          // and recycle everything
-          setTimeout(function () {
-            if (isError) {
-              participantsState[uuid] = participantState.notRunning;
-            }
-            return resolve(null);
-          }, 1000);
-        });
       });
-    });
+    };
+
+    runTestFunction();
   }
-);
+ );
 
 test('Discovered peer should be removed if no availability updates ' +
   'were received during availability timeout', function (t) {


### PR DESCRIPTION
This is based on timer, because of possible race condition in case when we try to restart ThaliMobile (call stop and start) whenever any error occurs. Currently this test is at most ran 5 times, which I believe is more than enough. However, sometimes my Nexus can get into very sad state, that it is really really slow and doesn't make any connections, so it is still possible that this test will fail after 5 retries, but it clearly tells us that nexus bluetooth is pretty bad.

Fix for thaliproject/Thali_CordovaPlugin#1594 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1715)
<!-- Reviewable:end -->