### PR TITLE
#1813 Fix inconsistent ThaliPeerPool enqueue API

### DIFF
--- a/test/www/jxcore/bv_tests/testThaliManagerCoordinated.js
+++ b/test/www/jxcore/bv_tests/testThaliManagerCoordinated.js
@@ -73,7 +73,7 @@ function debug() {
     }
     try {
       return JSON.stringify(arg, null, 2);
-    } catch(e) {
+    } catch (e) {
       return String(arg);
     }
   });

--- a/test/www/jxcore/bv_tests/testThaliNotificationClient.js
+++ b/test/www/jxcore/bv_tests/testThaliNotificationClient.js
@@ -446,6 +446,37 @@ test('Resolves an action locally', function (t) {
   notificationClient._peerAvailabilityChanged(globals.TCPEvent);
 });
 
+test('Ignores errors thrown by peerPool.enqueue', function (t) {
+  var getPeerHostInfoStub = stubGetPeerHostInfo();
+  var peerPool = {
+    enqueue: function () {
+      throw new Error('oops');
+    }
+  };
+
+  var notificationClient =
+    new ThaliNotificationClient(peerPool,
+      globals.sourceKeyExchangeObject, function () {});
+
+  notificationClient.start([]);
+
+  var TCPEvent = {
+    peerIdentifier: 'id3212',
+    peerAvailable: true,
+    newAddressPort: true,
+    generation: 0,
+    connectionType: ThaliMobileNativeWrapper.connectionTypes.TCP_NATIVE
+  };
+
+  t.doesNotThrow(function () {
+    notificationClient._peerAvailabilityChanged(TCPEvent);
+  });
+
+  notificationClient.stop();
+  getPeerHostInfoStub.restore();
+  t.end();
+});
+
 test('Resolves an action locally using ThaliPeerPoolDefault', function (t) {
 
   // Scenario:

--- a/test/www/jxcore/bv_tests/testThaliPeerPoolDefault.js
+++ b/test/www/jxcore/bv_tests/testThaliPeerPoolDefault.js
@@ -221,7 +221,7 @@ test('#ThaliPeerPoolDefault - stop', function (t) {
       function () {
         testThaliPeerPoolDefault.enqueue(testAction3);
       },
-      ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED,
+      new RegExp(ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED),
       'enqueue is not available when stopped'
     );
 

--- a/test/www/jxcore/bv_tests/testThaliPeerPoolDefault.js
+++ b/test/www/jxcore/bv_tests/testThaliPeerPoolDefault.js
@@ -216,9 +216,12 @@ test('#ThaliPeerPoolDefault - stop', function (t) {
     var testAction3 = new TestPeerAction(
       peerIdentifier, connectionType, actionType, t
     );
-    var error = testThaliPeerPoolDefault.enqueue(testAction3);
-    t.equal(
-      error.message, ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED,
+
+    t.throws(
+      function () {
+        testThaliPeerPoolDefault.enqueue(testAction3);
+      },
+      ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED,
       'enqueue is not available when stopped'
     );
 
@@ -241,5 +244,5 @@ test('#ThaliPeerPoolDefault - stop', function (t) {
     );
 
     t.end();
-  })
+  });
 });

--- a/thali/NextGeneration/notification/thaliNotificationClient.js
+++ b/thali/NextGeneration/notification/thaliNotificationClient.js
@@ -79,6 +79,7 @@ function ThaliNotificationClient(thaliPeerPoolInterface, ecdhForLocalDevice) {
   assert(ecdhForLocalDevice,
     ThaliNotificationClient.Errors.EDCH_FOR_LOCAL_DEVICE_NOT_NULL);
 
+  this._isStarted = false;
   this.peerDictionary = null;
   this._thaliPeerPoolInterface = thaliPeerPoolInterface;
   this._ecdhForLocalDevice = ecdhForLocalDevice;
@@ -156,7 +157,6 @@ ThaliNotificationClient.prototype.start =
 
     this._publicKeysToListen = [];
     this._publicKeysToListenHashes = [];
-
     this._publicKeysToListen = publicKeysToListen;
 
     publicKeysToListen.forEach(function (pubKy) {
@@ -164,11 +164,12 @@ ThaliNotificationClient.prototype.start =
         NotificationBeacons.createPublicKeyHash(pubKy));
     });
 
-    if (!this.peerDictionary) {
+    if (!this._isStarted) {
       ThaliMobile.emitter.on('peerAvailabilityChanged',
         this._boundListener);
     }
     this.peerDictionary = new PeerDictionary.PeerDictionary();
+    this._isStarted = true;
   };
 
 /**
@@ -180,7 +181,9 @@ ThaliNotificationClient.prototype.start =
  * @public
  */
 ThaliNotificationClient.prototype.stop = function () {
-  if (this.peerDictionary) {
+  if (this._isStarted) {
+    this._isStarted = false;
+    assert(this.peerDictionary, 'peer dictionary exists');
     ThaliMobile.emitter.removeListener('peerAvailabilityChanged',
       this._boundListener);
 
@@ -212,11 +215,7 @@ ThaliNotificationClient.prototype._peerAvailabilityChanged =
   function (peerStatus) {
     var self = this;
 
-    if (!this.peerDictionary) {
-      logger.warn('no dictionary');
-      return;
-    }
-
+    assert(self.peerDictionary, 'peer dictionary exists');
     assert(peerStatus, 'peerStatus must not be null or undefined');
     assert(peerStatus.peerIdentifier, 'peerIdentifier must be set');
     assert(peerStatus.connectionType, 'connectionType must be set');
@@ -266,13 +265,12 @@ ThaliNotificationClient.prototype._createNotificationAction =
 
     peerEntry.notificationAction = action;
 
-    var enqueueError = this._thaliPeerPoolInterface.enqueue(action);
-
-    if (!enqueueError) {
+    try {
+      this._thaliPeerPoolInterface.enqueue(action);
       this.peerDictionary.addUpdateEntry(peer, peerEntry);
-    } else {
+    } catch (error) {
       logger.warn('_createAndEnqueueAction: failed to enqueue an item: %s',
-        enqueueError.message);
+        error.message);
     }
   };
 

--- a/thali/NextGeneration/notification/thaliNotificationClient.js
+++ b/thali/NextGeneration/notification/thaliNotificationClient.js
@@ -269,8 +269,7 @@ ThaliNotificationClient.prototype._createNotificationAction =
       this._thaliPeerPoolInterface.enqueue(action);
       this.peerDictionary.addUpdateEntry(peer, peerEntry);
     } catch (error) {
-      logger.warn('_createAndEnqueueAction: failed to enqueue an item: %s',
-        error.message);
+      this.emit('error', error);
     }
   };
 

--- a/thali/NextGeneration/replication/thaliPullReplicationFromNotification.js
+++ b/thali/NextGeneration/replication/thaliPullReplicationFromNotification.js
@@ -136,10 +136,10 @@ ThaliPullReplicationFromNotification.prototype._peerAdvertisesDataForUsHandler =
     this._peerDictionary[key] = newAction;
     this._bindRemoveActionFromPeerDictionary(newAction, key);
 
-    var enqueueError = this._thaliPeerPoolInterface.enqueue(newAction);
-    if (enqueueError) {
-      logger.warn('_peerAdvertisesDataForUsHandler: failed to enqueue an item: %s',
-        enqueueError.message);
+    try {
+      this._thaliPeerPoolInterface.enqueue(newAction);
+    } catch (error) {
+      this.emit('error', error);
     }
   };
 
@@ -248,6 +248,8 @@ ThaliPullReplicationFromNotification.prototype.stop = function () {
     'ThaliPullReplicationFromNotification state should be \'STARTED\' for stop'
   );
   self.state = ThaliPullReplicationFromNotification.STATES.STOPPED;
+
+  self._thaliPeerPoolInterface.stop();
 
   self._thaliNotificationClient.removeListener(
     self._thaliNotificationClient.Events.PeerAdvertisesDataForUs,

--- a/thali/NextGeneration/thaliPeerPool/thaliPeerPoolDefault.js
+++ b/thali/NextGeneration/thaliPeerPool/thaliPeerPoolDefault.js
@@ -77,7 +77,7 @@ ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED =
 ThaliPeerPoolDefault.prototype.enqueue = function (peerAction) {
   if (this._stopped) {
     peerAction.kill();
-    return new Error(ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED);
+    throw new Error(ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED);
   }
 
   // Right now we will just allow everything to run parallel.
@@ -117,6 +117,7 @@ ThaliPeerPoolDefault.prototype.start = function () {
  * kill any actions that this pool has started that haven't already been
  * killed. It will also return errors if any further attempts are made
  * to enqueue.
+ * @return {Promise}
  */
 ThaliPeerPoolDefault.prototype.stop = function () {
   this._stopped = true;

--- a/thali/NextGeneration/thaliPeerPool/thaliPeerPoolOneAtATime.js
+++ b/thali/NextGeneration/thaliPeerPool/thaliPeerPoolOneAtATime.js
@@ -163,7 +163,7 @@ ThaliPeerPoolOneAtATime.prototype._bluetoothReplicationAction = null;
  * Runs the replication action and if it fails for a reason other than a
  * timeout and if the peer is still available (meaning the connection has not
  * been lost) then we will retry the replication.
- * @param replicationAction
+ * @param {module:thaliPeerAction~PeerAction} replicationAction
  * @returns {Promise.<null>}
  * @private
  */
@@ -237,7 +237,7 @@ ThaliPeerPoolOneAtATime.prototype._bluetoothEnqueue = function (peerAction) {
       peerAction.getActionType());
     logger.error(error.message);
     peerAction.kill();
-    return error;
+    throw error;
   }
 
   self._bluetoothSerialPromiseQueue.enqueue(function (resolve) {
@@ -275,37 +275,32 @@ ThaliPeerPoolOneAtATime.prototype._bluetoothEnqueue = function (peerAction) {
 ThaliPeerPoolOneAtATime.prototype.enqueue = function (peerAction) {
   if (this._stopped) {
     peerAction.kill();
-    return new Error(ThaliPeerPoolOneAtATime.ERRORS.ENQUEUE_WHEN_STOPPED);
+    throw new Error(ThaliPeerPoolOneAtATime.ERRORS.ENQUEUE_WHEN_STOPPED);
   }
-  var result =
-    ThaliPeerPoolOneAtATime.super_.prototype.enqueue.apply(this, arguments);
+  ThaliPeerPoolOneAtATime.super_.prototype.enqueue.apply(this, arguments);
 
-  if (result) {
-    return result;
-  }
-
-  switch(peerAction.getConnectionType()) {
+  switch (peerAction.getConnectionType()) {
     // MPCF is here because right now master doesn't really know how to set
     // the mock type to anything but Android
     case thaliMobileNativeWrapper.connectionTypes
       .MULTI_PEER_CONNECTIVITY_FRAMEWORK:
     case thaliMobileNativeWrapper.connectionTypes.BLUETOOTH: {
-      result = this._bluetoothEnqueue(peerAction);
+      this._bluetoothEnqueue(peerAction);
       break;
     }
     case thaliMobileNativeWrapper.connectionTypes.TCP_NATIVE: {
-      result = this._wifiEnqueue(peerAction);
+      this._wifiEnqueue(peerAction);
       break;
     }
     default: {
       peerAction.kill();
-      result = new Error('Got unrecognized connection type: ' +
+      throw new Error('Got unrecognized connection type: ' +
         peerAction.getConnectionType());
       break;
     }
   }
 
-  return result instanceof Error ? result : null;
+  return null;
 };
 
 ThaliPeerPoolOneAtATime.prototype.start = function () {
@@ -320,6 +315,7 @@ ThaliPeerPoolOneAtATime.prototype.start = function () {
  * kill any actions that this pool has started that haven't already been
  * killed. It will also return errors if any further attempts are made
  * to enqueue.
+ * @return {Promise}
  */
 ThaliPeerPoolOneAtATime.prototype.stop = function () {
   logger.debug('Stop was called');


### PR DESCRIPTION
1. Makes all ThaliPeerPoolInterface implementations to always throw when invalid action is being enqueued.
2. Updates thaliNotificationClient to use `try-catch` instead of checking returned value

This is a **breaking change**. If you use custom thaliPeerPool implementation you have to throw errors from the `enqueue` method instead of returning them. 

Fixes #1813.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1814)
<!-- Reviewable:end -->
