### PR TITLE
#1813 Fix inconsistent ThaliPeerPool enqueue API

### DIFF
--- a/test/www/jxcore/bv_tests/testThaliManager.js
+++ b/test/www/jxcore/bv_tests/testThaliManager.js
@@ -59,15 +59,8 @@ function Mocks(t) {
   this.MobileStartLA = sinon.spy(
     this.ThaliMobile, 'startListeningForAdvertisements'
   );
-  this.MobileStopLA = sinon.spy(
-    this.ThaliMobile, 'stopListeningForAdvertisements'
-  );
-
   this.MobileStartUAA = sinon.spy(
     this.ThaliMobile, 'startUpdateAdvertisingAndListening'
-  );
-  this.MobileStopUAA = sinon.spy(
-    this.ThaliMobile, 'stopAdvertisingAndListening'
   );
 
   this.Notification = sinon.spy(
@@ -116,10 +109,8 @@ Mocks.prototype.resetStartStop = function() {
   this.MobileStop.reset();
 
   this.MobileStartLA.reset();
-  this.MobileStopLA.reset();
 
   this.MobileStartUAA.reset();
-  this.MobileStopUAA.reset();
 
   this.NotificationStart.reset();
   this.NotificationStop.reset();
@@ -144,8 +135,6 @@ Mocks.prototype.checkStart = function(partnerKeys, networkType) {
 };
 Mocks.prototype.checkStop = function() {
   this.checkMobileStop();
-  this.checkMobileStopLA();
-  this.checkMobileStopUAA();
   this.checkNotificationStop();
   this.checkReplicationStop();
 };
@@ -352,20 +341,6 @@ Mocks.prototype.checkMobileStartUAA = function() {
 Mocks.prototype.checkMobileStop = function() {
   testUtils.checkArgs(
     this.t, this.MobileStop, 'ThaliMobile.stop', []
-  );
-};
-Mocks.prototype.checkMobileStopLA = function() {
-  testUtils.checkArgs(
-    this.t, this.MobileStopLA,
-    'ThaliMobile.stopListeningForAdvertisements',
-    []
-  );
-};
-Mocks.prototype.checkMobileStopUAA = function() {
-  testUtils.checkArgs(
-    this.t, this.MobileStopUAA,
-    'ThaliMobile.stopAdvertisingAndListening',
-    []
   );
 };
 

--- a/test/www/jxcore/bv_tests/testThaliManagerCoordinated.js
+++ b/test/www/jxcore/bv_tests/testThaliManagerCoordinated.js
@@ -73,7 +73,7 @@ function debug() {
     }
     try {
       return JSON.stringify(arg, null, 2);
-    } catch(e) {
+    } catch (e) {
       return String(arg);
     }
   });

--- a/test/www/jxcore/bv_tests/testThaliNotificationClient.js
+++ b/test/www/jxcore/bv_tests/testThaliNotificationClient.js
@@ -446,6 +446,37 @@ test('Resolves an action locally', function (t) {
   notificationClient._peerAvailabilityChanged(globals.TCPEvent);
 });
 
+test('Ignores errors thrown by peerPool.enqueue', function (t) {
+  var getPeerHostInfoStub = stubGetPeerHostInfo();
+  var peerPool = {
+    enqueue: function () {
+      throw new Error('oops');
+    }
+  };
+
+  var notificationClient =
+    new ThaliNotificationClient(peerPool,
+      globals.sourceKeyExchangeObject, function () {});
+
+  notificationClient.start([]);
+
+  var TCPEvent = {
+    peerIdentifier: 'id3212',
+    peerAvailable: true,
+    newAddressPort: true,
+    generation: 0,
+    connectionType: ThaliMobileNativeWrapper.connectionTypes.TCP_NATIVE
+  };
+
+  t.doesNotThrow(function () {
+    notificationClient._peerAvailabilityChanged(TCPEvent);
+  });
+
+  notificationClient.stop();
+  getPeerHostInfoStub.restore();
+  t.end();
+});
+
 test('Resolves an action locally using ThaliPeerPoolDefault', function (t) {
 
   // Scenario:

--- a/test/www/jxcore/bv_tests/testThaliPeerPoolDefault.js
+++ b/test/www/jxcore/bv_tests/testThaliPeerPoolDefault.js
@@ -216,9 +216,12 @@ test('#ThaliPeerPoolDefault - stop', function (t) {
     var testAction3 = new TestPeerAction(
       peerIdentifier, connectionType, actionType, t
     );
-    var error = testThaliPeerPoolDefault.enqueue(testAction3);
-    t.equal(
-      error.message, ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED,
+
+    t.throws(
+      function () {
+        testThaliPeerPoolDefault.enqueue(testAction3);
+      },
+      new RegExp(ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED),
       'enqueue is not available when stopped'
     );
 
@@ -241,5 +244,5 @@ test('#ThaliPeerPoolDefault - stop', function (t) {
     );
 
     t.end();
-  })
+  });
 });

--- a/thali/NextGeneration/notification/thaliNotificationClient.js
+++ b/thali/NextGeneration/notification/thaliNotificationClient.js
@@ -272,8 +272,7 @@ ThaliNotificationClient.prototype._createNotificationAction =
       this._thaliPeerPoolInterface.enqueue(action);
       this.peerDictionary.addUpdateEntry(peer, peerEntry);
     } catch (error) {
-      logger.warn('_createAndEnqueueAction: failed to enqueue an item: %s',
-        error.message);
+      this.emit('error', error);
     }
   };
 

--- a/thali/NextGeneration/thaliManager.js
+++ b/thali/NextGeneration/thaliManager.js
@@ -208,33 +208,17 @@ ThaliManager.prototype.stop = function () {
   );
   self.state = ThaliManager.STATES.STOPPING;
 
-  logger.debug('stopping thaliPeerPoolInterface');
-  self._stoppingPromise = self._thaliPeerPoolInterface.stop()
-    .then(function () {
-      logger.debug('stopping thaliPullReplicationFromNotification');
-      return self._thaliPullReplicationFromNotification.stop();
-    })
-    .then(function () {
-      logger.debug('stopping thaliSendNotificationBasedOnReplication');
-      return self._thaliSendNotificationBasedOnReplication.stop();
-    })
-    .then(function () {
-      logger.debug('stopping advertising and listening');
-      return ThaliMobile.stopAdvertisingAndListening();
-    })
-    .then(function () {
-      logger.debug('stopping listening for advertisements');
-      return ThaliMobile.stopListeningForAdvertisements();
-    })
-    .then(function () {
-      logger.debug('stopping ThaliMobile');
-      return ThaliMobile.stop();
-    })
-    .then(function () {
-      self.state = ThaliManager.STATES.STOPPED;
-      self._stoppingPromise = undefined;
-      return true;
-    });
+  logger.debug('stopping everything');
+  self._stoppingPromise = Promise.all([
+    ThaliMobile.stop(),
+    this._thaliPeerPoolInterface.stop(),
+    this._thaliPullReplicationFromNotification.stop(),
+    this._thaliSendNotificationBasedOnReplication.stop(),
+  ]).then(function () {
+    self.state = ThaliManager.STATES.STOPPED;
+    self._stoppingPromise = undefined;
+    return true;
+  });
 
   return self._stoppingPromise;
 };

--- a/thali/NextGeneration/thaliPeerPool/thaliPeerPoolDefault.js
+++ b/thali/NextGeneration/thaliPeerPool/thaliPeerPoolDefault.js
@@ -77,7 +77,7 @@ ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED =
 ThaliPeerPoolDefault.prototype.enqueue = function (peerAction) {
   if (this._stopped) {
     peerAction.kill();
-    return new Error(ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED);
+    throw new Error(ThaliPeerPoolDefault.ERRORS.ENQUEUE_WHEN_STOPPED);
   }
 
   // Right now we will just allow everything to run parallel.
@@ -117,6 +117,7 @@ ThaliPeerPoolDefault.prototype.start = function () {
  * kill any actions that this pool has started that haven't already been
  * killed. It will also return errors if any further attempts are made
  * to enqueue.
+ * @return {Promise}
  */
 ThaliPeerPoolDefault.prototype.stop = function () {
   this._stopped = true;

--- a/thali/NextGeneration/thaliPeerPool/thaliPeerPoolOneAtATime.js
+++ b/thali/NextGeneration/thaliPeerPool/thaliPeerPoolOneAtATime.js
@@ -131,8 +131,7 @@ ThaliPeerPoolOneAtATime.prototype._wifiEnqueue = function (peerAction) {
     }
   }
 
-  var originalKill = peerAction.kill;
-  peerAction.kill = function () {
+  peerAction.on('killed', function () {
     var count = self._wifiReplicationCount[peerId];
     switch (count) {
       case 1: {
@@ -147,8 +146,7 @@ ThaliPeerPoolOneAtATime.prototype._wifiEnqueue = function (peerAction) {
         logger.error('Count had to be 1 or 2 - ' + count);
       }
     }
-    return originalKill.apply(this, arguments);
-  };
+  });
 
   self._replicateThroughProblems(peerAction)
     .then(function () {


### PR DESCRIPTION
This is a **breaking change**. If you use custom thaliPeerPool implementation you have to throw errors from the `enqueue` method instead of returning them. 

Fixes #1813.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1816)
<!-- Reviewable:end -->
