### PR TITLE
Fix wifi network changes handling

### DIFF
--- a/thali/NextGeneration/thaliWifiInfrastructure.js
+++ b/thali/NextGeneration/thaliWifiInfrastructure.js
@@ -748,6 +748,13 @@ function (newStatus) {
     }
   }
 
+  if (connectedToAP || changedAP) {
+    // TODO: advertiser should provide API to update its advertising hostname or
+    // it should handle network changes itself
+    this.advertiser.routerServerAddress = ip.address();
+    this.advertiser._updateLocation();
+  }
+
   Promise.all(actionResults).then(function (results) {
     results.forEach(function (result) {
       if (result) {


### PR DESCRIPTION
Previously `bssidName:<MAC address>` → `bssidName:null` was considered as simple BSSID change and wifiInfrastructure was restarting ssdp client and server. SSDP start always fails when bssidName is null because it means that we are not connected to any access point and couldn't advertise anything.

In reality bssid change from/to null should be handled the same way as enabling/disabling WiFi on device.

Fixes #1823.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1826)
<!-- Reviewable:end -->
