### PR TITLE
Refactor promiseQueue implementation

### DIFF
--- a/thali/NextGeneration/promiseQueue.js
+++ b/thali/NextGeneration/promiseQueue.js
@@ -26,7 +26,6 @@ var Promise = require('lie');
  */
 function PromiseQueue () {
   this._running = false;
-  this._activePromise = null;
   this._tasks = [];
   this._run = this._run.bind(this);
 }
@@ -130,10 +129,9 @@ PromiseQueue.prototype._processQueue = function () {
 PromiseQueue.prototype._run = function () {
   var task = this._tasks.shift();
   if (task) {
-    this._activePromise = task.promise.then(this._run, this._run);
+    task.promise.then(this._run, this._run);
     task.run();
   } else {
-    this._activePromise = null;
     this._running = false;
   }
 };


### PR DESCRIPTION
1. Fix unhandled rejections when function passed into enqueue method throws an error.
2. Refactor internal implementation so it create only one promise when someone enqueues new executor. Also it does not build entire promise chain after calling `enqueue` but rather chains next promise right before the next task starts.
3. Tests, of course.

Fixes #1044

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1848)
<!-- Reviewable:end -->
