### PR TITLE
Fix failing Can shift data test on dekstop

### DIFF
--- a/test/www/jxcore/bv_tests/testHttp.js
+++ b/test/www/jxcore/bv_tests/testHttp.js
@@ -15,7 +15,7 @@ var httpServer = null;
 
 var test = tape({
   setup: function (t) {
-    httpServer = makeIntoCloseAllServer(http.createServer());
+    httpServer = makeIntoCloseAllServer(http.createServer(), true);
     t.end();
   },
   teardown: function (t) {

--- a/test/www/jxcore/bv_tests/testThaliMobileNative.js
+++ b/test/www/jxcore/bv_tests/testThaliMobileNative.js
@@ -370,16 +370,36 @@ function onConnectFailure(t, error) {
   t.end();
 }
 
-test('Can shift data', function (t) {
-  var connecting = false;
-  var exchangeData = 'small amount of data';
+function shiftData(sock, exchangeData) {
+  return new Promise(function (resolve, reject) {
+    sock.on('error', function (error) {
+      console.log('Client socket error:', error.message, error.stack);
+      reject(error);
+    });
 
-  var formatPrintableData = function (data) {
-    var ellipsis = data.length > 40 ? '...' : '';
-    return '<' + data.slice(0, 40) + ellipsis + '>';
-  };
+    var receivedData = '';
+    sock.on('data', function (chunk) {
+      receivedData += chunk.toString();
+      if (receivedData === exchangeData) {
+        sock.destroy();
+      }
+    });
 
-  var server = net.createServer(function (socket) {
+    sock.on('close', function () {
+      resolve();
+    });
+
+    var rawData = new Buffer(exchangeData);
+    logger.debug('Client sends data (%d bytes):',
+      rawData.length);
+    sock.write(rawData, function () {
+      logger.debug('Client data flushed');
+    });
+  });
+}
+
+function createServer(dataLength, formatPrintableData) {
+  return net.createServer(function (socket) {
     var ended = false;
     var buffer = '';
     socket.on('data', function (chunk) {
@@ -388,7 +408,7 @@ test('Can shift data', function (t) {
         chunk.length, formatPrintableData(chunk.toString()));
 
       // when received all data, send it back
-      if (buffer.length === exchangeData.length) {
+      if (buffer.length === dataLength) {
         console.log('Server received all data: %s',
           formatPrintableData(buffer.toString()));
         var rawData = new Buffer(buffer);
@@ -413,43 +433,27 @@ test('Can shift data', function (t) {
       t.fail(error.message);
     });
   });
+}
+
+test('Can shift data', function (t) {
+  var connecting = false;
+  var exchangeData = 'small amount of data';
+
+  var formatPrintableData = function (data) {
+    var ellipsis = data.length > 40 ? '...' : '';
+    return '<' + data.slice(0, 40) + ellipsis + '>';
+  };
+
+  var server = createServer(exchangeData.length, formatPrintableData);
   server = makeIntoCloseAllServer(server);
   serverToBeClosed = server;
-
-  function shiftData(sock) {
-    return new Promise(function (resolve, reject) {
-      sock.on('error', function (error) {
-        console.log('Client socket error:', error.message, error.stack);
-        reject(error);
-      });
-
-      var receivedData = '';
-      sock.on('data', function (chunk) {
-        receivedData += chunk.toString();
-        if (receivedData === exchangeData) {
-          sock.destroy();
-        }
-      });
-
-      sock.on('close', function () {
-        resolve();
-      });
-
-      var rawData = new Buffer(exchangeData);
-      logger.debug('Client sends data (%d bytes):',
-        rawData.length);
-      sock.write(rawData, function () {
-        logger.debug('Client data flushed');
-      });
-    });
-  }
 
   function onConnectSuccess(err, connection) {
     var nativePort = connection.listeningPort;
 
     connect(net, { port: nativePort })
     .then(function (socket) {
-      return shiftData(socket);
+      return shiftData(socket, exchangeData);
     })
     .catch(t.fail)
     .then(function () {
@@ -485,70 +489,9 @@ test('Can shift data via parallel connections',
       return data;
     };
 
-    var server = net.createServer(function (socket) {
-      var ended = false;
-      var buffer = '';
-      socket.on('data', function (chunk) {
-        buffer += chunk.toString();
-        console.log('Server received (%d bytes): %s',
-          chunk.length, formatPrintableData(chunk.toString()));
-
-        // when received all data, send it back
-        if (buffer.length === dataLength) {
-          console.log('Server received all data: %s',
-            formatPrintableData(buffer.toString()));
-          var rawData = new Buffer(buffer);
-          console.log('Server sends data back to client (%d bytes): %s',
-            rawData.length, formatPrintableData(buffer));
-          socket.write(rawData, function () {
-            console.log('Server data flushed');
-          });
-          ended = true;
-          socket.end(function () {
-            console.log('Server\'s socket stream finished');
-          });
-        }
-      });
-      socket.on('end', function () {
-        // server ends connection, not client
-        if (!ended) {
-          t.fail(new Error('Unexpected end event'));
-        }
-      });
-      socket.on('error', function (error) {
-        t.fail(error.message);
-      });
-    });
+    var server = createServer(dataLength, formatPrintableData);
     server = makeIntoCloseAllServer(server);
     serverToBeClosed = server;
-
-    function shiftData(sock, exchangeData) {
-      return new Promise(function (resolve, reject) {
-        sock.on('error', function (error) {
-          console.log('Client socket error:', error.message, error.stack);
-          reject(error);
-        });
-
-        var receivedData = '';
-        sock.on('data', function (chunk) {
-          receivedData += chunk.toString();
-          if (receivedData === exchangeData) {
-            sock.destroy();
-          }
-        });
-
-        sock.on('close', function () {
-          resolve();
-        });
-
-        var rawData = new Buffer(exchangeData);
-        logger.debug('Client sends data (%d bytes):',
-          rawData.length);
-        sock.write(rawData, function () {
-          logger.debug('Client data flushed');
-        });
-      });
-    }
 
     function onConnectSuccess(err, connection) {
       var nativePort = connection.listeningPort;
@@ -587,17 +530,7 @@ test('Can shift data via parallel connections',
 
 test('Can shift data securely', function (t) {
   var connecting = false;
-  var dataSize = 16 * 1024;
-  var exchangeData = randomString.generate(dataSize);
-
-  var uuids = t.participants.map(function (p) { return p.uuid; });
-  assert(uuids.length === 2, 'This test requires exactly 2 devices');
-  uuids.sort();
-  var iAmFirst = (tape.uuid === uuids[0]);
-
-  var formatPrintableData = function (data) {
-    return data;
-  };
+  var exchangeData = 'small amount of data';
 
   var pskKey = new Buffer('psk-key');
   var pskId = 'psk-id';
@@ -615,22 +548,21 @@ test('Can shift data securely', function (t) {
     var buffer = '';
     socket.on('data', function (chunk) {
       buffer += chunk.toString();
-      console.log('Server received (%d bytes): %s',
-        chunk.length, formatPrintableData(chunk.toString()));
+      logger.debug('Server received (%d bytes):',
+        chunk.length);
 
       // when received all data, send it back
       if (buffer.length === exchangeData.length) {
-        console.log('Server received all data: %s',
-          formatPrintableData(buffer.toString()));
+        logger.debug('Server received all data: %s', buffer);
         var rawData = new Buffer(buffer);
-        console.log('Server sends data back to client (%d bytes): %s',
-          rawData.length, formatPrintableData(buffer));
+        logger.debug('Server sends data back to client (%d bytes): ',
+          rawData.length);
         socket.write(rawData, function () {
-          console.log('Server data flushed');
+          logger.debug('Server data flushed');
         });
         ended = true;
         socket.end(function () {
-          console.log('Server\'s socket stream finished');
+          logger.debug('Server\'s socket stream finished');
         });
       }
     });
@@ -649,16 +581,6 @@ test('Can shift data securely', function (t) {
   server = makeIntoCloseAllServer(server);
   serverToBeClosed = server;
 
-  var serverStarted = new Promise(function (resolve, reject) {
-    server.once('error', reject);
-    server.listen(0, function () {
-      server.removeListener('error', reject);
-      resolve(server);
-    });
-  });
-
-  var waitForServerEnd = waitForEvent(server, 'CLIENT_DONE');
-
   function shiftData(sock) {
     sock.on('error', function (error) {
       console.log('Client socket error:', error.message, error.stack);
@@ -668,18 +590,21 @@ test('Can shift data securely', function (t) {
     var receivedData = '';
     sock.on('data', function (chunk) {
       receivedData += chunk.toString();
+      if (receivedData === exchangeData) {
+        sock.destroy();
+      }
     });
-    sock.on('end', function () {
+    sock.on('close', function () {
       t.equal(receivedData, exchangeData, 'got the same data back');
     });
 
     var rawData = new Buffer(exchangeData);
-    console.log('Client sends data (%d bytes): %s',
-      rawData.length, formatPrintableData(exchangeData));
+    logger.debug('Client sends data (%d bytes):',
+      rawData.length);
     sock.write(rawData, function () {
-      console.log('Client data flushed');
+      logger.debug('Client data flushed');
     });
-    return waitForEvent(sock, 'end');
+    return waitForEvent(sock, 'close');
   }
 
   function startShiftData(port) {
@@ -687,37 +612,37 @@ test('Can shift data securely', function (t) {
       port: port,
       ciphers: thaliConfig.SUPPORTED_PSK_CIPHERS,
       pskIdentity: pskId,
-      pskKey: pskKey,
+      pskKey: pskKey
     })
-    .then(function (socket) {
-      return shiftData(socket);
-    });
+      .then(function (socket) {
+        return shiftData(socket);
+      });
   }
 
+  function onConnectSuccess(err, connection) {
+    var nativePort = connection.listeningPort;
 
-  serverStarted
-    .then(function (server) {
-      var port = server.address().port;
-      console.log('Test server is listening on the %d port', port);
-      return findPeerAndConnect(port);
-    })
-    .then(function (info) {
-      console.log('Native connection established. Info: %s',
-        JSON.stringify(info, null, 2));
-      var nativePort = info.connection.listeningPort;
-      if (iAmFirst) {
-        return startShiftData(nativePort);
-      }
-      return waitForServerEnd.then(function () {
-        return startShiftData(nativePort);
+    startShiftData(nativePort)
+      .catch(t.fail)
+      .then(function () {
+        t.end();
       });
-    })
-    .catch(function (err) {
-      t.fail(err.message + '\n' + err.stack);
-    })
-    .then(function () {
-      t.end();
+  }
+
+  thaliMobileNativeTestUtils.startAndListen(t, server, function (peers) {
+    peers.forEach(function (peer) {
+      if (peer.peerAvailable && !connecting) {
+        connecting = true;
+        thaliMobileNativeTestUtils.connectToPeer(peer)
+          .then(function (connection) {
+            onConnectSuccess(null, connection, peer);
+          })
+          .catch(function (error) {
+            onConnectFailure(t, error, null, peer);
+          });
+      }
     });
+  });
 });
 
 test('Can shift large amounts of data', function (t) {
@@ -810,7 +735,6 @@ test('Can shift large amounts of data', function (t) {
   });
 
   echoServer.listen(0, function () {
-
     var applicationPort = echoServer.address().port;
 
     Mobile('startUpdateAdvertisingAndListening').callNative(applicationPort,


### PR DESCRIPTION
Also contains fix for #1864 . These tests were failing on desktop because there is one particular test which is fired only on iOS devices, but in teardown we always try to kill http server, even if it was not started. So the fix is to pass additional argument to `makeIntoCloseAllServer`, which causes that if fail while closing server occur it is does not cause tests to fail.

If it comes to fix for #1866 , it looks like the functions which are used in `Can shift data` and `Can shift data via parallel connections` were removed after merge with master. The fix contains these functions restored which makes tests pass on desktop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1867)
<!-- Reviewable:end -->
