### PR TITLE
Fix failing test on iOS devices #1871

### DIFF
--- a/test/www/jxcore/bv_tests/testThaliMobile.js
+++ b/test/www/jxcore/bv_tests/testThaliMobile.js
@@ -1087,6 +1087,9 @@ test('networkChanged - fires peerAvailabilityChanged event for native peers ' +
     ThaliMobile.start(express.Router()).then(function () {
       // Add initial peers
       emitNativePeerAvailability(testPeers.nativePeer);
+    }).catch(function (err) {
+      t.fail('ThaliMobile couldn\'t be started!');
+      end();
     });
   }
 );

--- a/test/www/jxcore/bv_tests/testThaliMobile.js
+++ b/test/www/jxcore/bv_tests/testThaliMobile.js
@@ -1082,7 +1082,7 @@ test('networkChanged - fires peerAvailabilityChanged event for native peers ' +
       t.end();
     }
 
-    // Make sure ThaliMobile is started before we begin this test, otherwise emitted event `networkChangedNonTCP`
+    // Make sure ThaliMobile is started before we begin this test, otherwise events `networkChangedNonTCP`
     // will be filtered out.
     ThaliMobile.start(express.Router()).then(function () {
       // Add initial peers

--- a/test/www/jxcore/bv_tests/testThaliMobile.js
+++ b/test/www/jxcore/bv_tests/testThaliMobile.js
@@ -1019,7 +1019,7 @@ test('networkChanged - fires peerAvailabilityChanged event for native peers ' +
     function disableBluetooth() {
       ThaliMobileNativeWrapper.emitter.emit('networkChangedNonTCP', {
         wifi: radioState.ON,
-        bssidName: null,
+        bssidName: '00:00:00:00:00:00',
         bluetoothLowEnergy: radioState.ON,
         bluetooth: radioState.OFF,
         cellular: radioState.ON
@@ -1063,6 +1063,9 @@ test('networkChanged - fires peerAvailabilityChanged event for native peers ' +
             t.fail('Got peerAvailabilityChanged before wifi was disabled');
           }
           t.equals(peerStatus.peerAvailable, false, 'peer became unavailable');
+          break;
+        case 4:
+          t.equals(peerStatus.peerAvailable, false, 'peer became unavailable');
           setImmediate(end);
           break;
         default:
@@ -1079,8 +1082,12 @@ test('networkChanged - fires peerAvailabilityChanged event for native peers ' +
       t.end();
     }
 
-    // Add initial peers
-    emitNativePeerAvailability(testPeers.nativePeer);
+    // Make sure ThaliMobile is started before we begin this test, otherwise emitted event `networkChangedNonTCP`
+    // will be filtered out.
+    ThaliMobile.start(express.Router()).then(function () {
+      // Add initial peers
+      emitNativePeerAvailability(testPeers.nativePeer);
+    });
   }
 );
 


### PR DESCRIPTION
First of all, before starting this test we need to make sure that ThaliMobile is started. 
Otherwise, `networkChangedNonTCP` events will be filtered out.

Based on test assumptions that we discover 1 peer via WiFi and 1 peer via MPCF,
we can safely assume that phone is connected to access point so the `bbsidName` field
is set to some non null value. This is because `networkChangedValue` with `bssidName` set to null is treated same as WiFi off.
See #1500 and #1707 for details.

Also, since this scenario assume that after disabling WiFi `peerAvailabilityChanged` event would
be fired twice, we need to increase `availibilityHandler` calls limit by one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1872)
<!-- Reviewable:end -->
