### PR TITLE
Provide remote db name for ThaliReplicationPeerAction during runtime #1873

### DIFF
--- a/test/www/jxcore/bv_tests/testThaliManagerCoordinated.js
+++ b/test/www/jxcore/bv_tests/testThaliManagerCoordinated.js
@@ -26,7 +26,8 @@ var ecdhForLocalDevice = crypto.createECDH(thaliConfig.BEACON_CURVE);
 var publicKeyForLocalDevice = ecdhForLocalDevice.generateKeys();
 var publicBase64KeyForLocalDevice = ecdhForLocalDevice.getPublicKey('base64');
 
-// PouchDB name should be the same between peers.
+// PouchDB name can be the same between peers or can be provided directly to
+// ThaliReplicationPeerAction.start.
 var DB_NAME = 'ThaliManagerCoordinated';
 
 PouchDB = testUtils.getLevelDownPouchDb();

--- a/test/www/jxcore/bv_tests/testThaliReplicationPeerAction.js
+++ b/test/www/jxcore/bv_tests/testThaliReplicationPeerAction.js
@@ -221,11 +221,7 @@ function matchDocsInChanges(pouchDB, docs, thaliPeerReplicationAction) {
   });
 }
 
-test('Make sure docs replicate',
-  function () {
-    // FIXME: iOS is too slow for this test (#1618)
-    return platform._isRealIOS;
-  },
+test('Make sure docs replicate with remote db with same name as local db',
   function (t) {
     testCloseAllServer = testUtils.setUpServer(function (serverPort,
                                                          randomDBName,
@@ -275,11 +271,58 @@ test('Make sure docs replicate',
     });
   });
 
+test('Make sure docs replicate with remote db with different name than local db',
+  function (t) {
+    testCloseAllServer = testUtils.setUpServer(function (serverPort,
+                                                         randomRemoteDBName,
+                                                         remotePouchDB) {
+      var thaliReplicationPeerAction = null;
+      var DifferentDirectoryPouch = testUtils.getLevelDownPouchDb();
+      var localDBName = testUtils.getRandomPouchDBName();
+      var localPouchDB = new DifferentDirectoryPouch(localDBName);
+      createDocs(remotePouchDB, 10)
+        .then(function (docs) {
+          var notificationForUs = {
+            keyId: new Buffer('abcdefg'),
+            portNumber: serverPort,
+            hostAddress: '127.0.0.1',
+            pskIdentifyField: pskId,
+            psk: pskKey,
+            suggestedTCPTimeout: 10000,
+            connectionType: thaliMobileNativeWrapper.connectionTypes.TCP_NATIVE
+          };
+          var promises = [];
+          thaliReplicationPeerAction =
+            new ThaliReplicationPeerAction(notificationForUs,
+              DifferentDirectoryPouch, localDBName,
+              devicePublicKey);
+          promises.push(thaliReplicationPeerAction.start(httpAgentPool, randomRemoteDBName));
+          promises.push(matchDocsInChanges(localPouchDB, docs,
+            thaliReplicationPeerAction));
+          return Promise.all(promises);
+        })
+        .then(function () {
+          return remotePouchDB.info();
+        })
+        .then(function (info) {
+          return httpTester.validateSeqNumber(t, randomRemoteDBName, serverPort,
+            // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+            info.update_seq, pskId, pskKey, devicePublicKey, null, 10);
+          // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
+        })
+        .then(function () {
+          t.pass('All tests passed!');
+        })
+        .catch(function (err) {
+          t.fail('failed with ' + err);
+        })
+        .then(function () {
+          t.end();
+        });
+    });
+  });
+
 test('Do nothing and make sure we time out',
-  function () {
-    // FIXME: iOS is too slow for this test (#1618)
-    return platform._isRealIOS;
-  },
   function (t) {
     function onServerSetUp (serverPort, randomDBName) {
       var thaliReplicationPeerAction = null;
@@ -330,10 +373,6 @@ test('Do nothing and make sure we time out',
 );
 
 test('Do something and make sure we time out',
-  function () {
-    // FIXME: iOS is too slow for this test (#1618)
-    return platform._isRealIOS;
-  },
   function (t) {
     function onServerSetUp (serverPort, randomDBName, remotePouchDB) {
       var thaliReplicationPeerAction = null;

--- a/test/www/jxcore/bv_tests/testThaliReplicationPeerAction.js
+++ b/test/www/jxcore/bv_tests/testThaliReplicationPeerAction.js
@@ -466,8 +466,8 @@ test('Make sure clone works', function (t) {
     'same getPeerAdvertisesDataForUs');
   t.equal(clonedAction._PouchDB, originalThaliReplicationAction._PouchDB,
     'Same pouchdB');
-  t.equal(clonedAction._dbName, originalThaliReplicationAction._dbName,
-    'same dbName');
+  t.equal(clonedAction._localDbName, originalThaliReplicationAction._localDbName,
+    'same localDbName');
   t.equal(clonedAction._ourPublicKey,
     originalThaliReplicationAction._ourPublicKey, 'Same public key');
   t.end();

--- a/test/www/jxcore/bv_tests/testThaliReplicationPeerActionCoordinated.js
+++ b/test/www/jxcore/bv_tests/testThaliReplicationPeerActionCoordinated.js
@@ -344,7 +344,7 @@ test('Coordinated replication action test - each device has different local db n
     });
 });
 
-test('Coordinated replication action test - should throw error when wrong dbRemoteName is provided', function (t) {
+test('Coordinated replication action test - should throw error when wrong remote db name is provided', function (t) {
   var wrongRemoteDbName = 'testDb';
   var router = express.Router();
   router.use(

--- a/test/www/jxcore/bv_tests/testThaliReplicationPeerActionCoordinated.js
+++ b/test/www/jxcore/bv_tests/testThaliReplicationPeerActionCoordinated.js
@@ -20,7 +20,12 @@ var devicePublicPrivateKey = crypto.createECDH(thaliConfig.BEACON_CURVE);
 var devicePublicKey        = devicePublicPrivateKey.generateKeys();
 var TestPouchDB            = testUtils.getLevelDownPouchDb();
 
-var DB_NAME            = 'repActionTest';
+// Use peer's public key to determine local db name. This variable is used in scenario when
+// we want to replicate with remote db which name is different than our local db.
+// In that case, we are able to determine peer's remote db name based on it's public key.
+// Use hex encoding to generate string without any special characters.
+var LOCAL_DB_NAME_BASED_ON_PUBLIC_KEY = devicePublicKey.toString('hex').slice(0, 10);
+var LOCAL_DB_NAME          = 'repActionTest';
 var EXPIRATION_TIMEOUT = 60 * 60 * 1000;
 
 if (!tape.coordinated) {
@@ -37,7 +42,7 @@ var test = tape({
   }
 });
 
-test('Coordinated replication action test', function (t) {
+test('Coordinated replication action test - each device has the same local db name', function (t) {
   var router = express.Router();
   router.use(
     '/db',
@@ -53,7 +58,7 @@ test('Coordinated replication action test', function (t) {
   var thaliNotificationClient = new ThaliNotificationClient(
     peerPool, devicePublicPrivateKey
   );
-  var localPouchDB = new TestPouchDB(DB_NAME);
+  var localPouchDB = new TestPouchDB(LOCAL_DB_NAME);
 
   var peerActions = [];
 
@@ -69,7 +74,7 @@ test('Coordinated replication action test', function (t) {
       devicePublicKey,
       function (notificationForUs) {
         var thaliReplicationPeerAction = new ThaliReplicationPeerAction(
-          notificationForUs, TestPouchDB, DB_NAME, devicePublicKey
+          notificationForUs, TestPouchDB, LOCAL_DB_NAME, devicePublicKey
         );
         peerActions.push(thaliReplicationPeerAction);
 
@@ -181,4 +186,154 @@ test('Coordinated replication action test', function (t) {
   .then(function () {
     t.end();
   });
+});
+
+test('Coordinated replication action test - each device has different local db name', function (t) {
+  var router = express.Router();
+  router.use(
+    '/db',
+    expressPouchDB(TestPouchDB, {
+      mode: 'minimumForPouchDB'
+    })
+  );
+  var thaliNotificationServer = new ThaliNotificationServer(
+    router, devicePublicPrivateKey, EXPIRATION_TIMEOUT
+  );
+  var peerPool = new ThaliPeerPoolDefault();
+  peerPool.start();
+  var thaliNotificationClient = new ThaliNotificationClient(
+    peerPool, devicePublicPrivateKey
+  );
+  var localPouchDB = new TestPouchDB(LOCAL_DB_NAME_BASED_ON_PUBLIC_KEY);
+
+  var peerActions = [];
+
+  localPouchDB.put({
+    _id: JSON.stringify(devicePublicKey.toJSON())
+  })
+    .then(function () {
+      return testUtils.runTestOnAllParticipants(
+        t, router,
+        thaliNotificationClient,
+        thaliNotificationServer,
+        ThaliMobile,
+        devicePublicKey,
+        function (notificationForUs) {
+          var thaliReplicationPeerAction = new ThaliReplicationPeerAction(
+            notificationForUs, TestPouchDB, LOCAL_DB_NAME_BASED_ON_PUBLIC_KEY, devicePublicKey
+          );
+          peerActions.push(thaliReplicationPeerAction);
+
+          return new Promise(function (resolve, reject) {
+            var changes = localPouchDB.changes({
+              since: 0,
+              live: true
+            });
+
+            var exited = false;
+            var resultError = null;
+            function exit(error) {
+              if (exited) {
+                return;
+              }
+              exited = true;
+
+              resultError = error;
+              changes.cancel();
+            }
+
+            changes.on('change', function (change) {
+              var bufferRemoteId = new Buffer(JSON.parse(change.id));
+              // note that the test might pass before we even start replicating
+              // because we already have the record from someone else, that's
+              // fine. We still guarantee at least one replication ran on each
+              // device.
+              if (Buffer.compare(notificationForUs.keyId, bufferRemoteId) === 0) {
+                exit();
+              }
+            })
+              .on('error', function (error) {
+                reject(error);
+              })
+              .on('complete', function () {
+                if (resultError) {
+                  reject(resultError);
+                } else {
+                  resolve();
+                }
+              });
+
+            var httpAgentPool = new ForeverAgent.SSL({
+              rejectUnauthorized: false,
+              maxSockets: 8,
+              ciphers: thaliConfig.SUPPORTED_PSK_CIPHERS,
+              pskIdentity: thaliReplicationPeerAction.getPskIdentity(),
+              pskKey: thaliReplicationPeerAction.getPskKey()
+            });
+
+            // Use peer's public key to determine it's individual local db name
+            var remoteDbName =
+              thaliReplicationPeerAction.getPeerIdentifier().toString('hex').slice(0, 10);
+
+            thaliReplicationPeerAction.start(httpAgentPool, remoteDbName)
+              .catch(function (error) {
+                exit(error);
+              });
+          });
+        }
+      )
+    })
+
+    .then(function () {
+      return t.sync();
+    })
+
+    .then(function () {
+      // We are simulating thaliPullReplicationFromNotification.stop() and
+      // thaliPeerPoolDefault.stop()
+      thaliNotificationClient.stop();
+      var promises = peerActions.map(function (peerAction) {
+        peerAction.kill();
+        return peerAction.waitUntilKilled();
+      });
+      return Promise.all(promises);
+    })
+    .then(function () {
+      // https://github.com/thaliproject/Thali_CordovaPlugin/issues/1138
+      // workaround for ECONNREFUSED and ECONNRESET from 'request.js' in
+      // 'pouchdb'.
+      return t.sync();
+    })
+    .then(function () {
+      return thaliNotificationServer.stop();
+    })
+    .then(function () {
+      return ThaliMobile.stop();
+    })
+    .then(function (combinedResult) {
+      if (
+        combinedResult.wifiResult   !== null ||
+        combinedResult.nativeResult !== null
+      ) {
+        return Promise.reject(
+          new Error(
+            'Had a failure in ThaliMobile.start - ',
+            JSON.stringify(combinedResult)
+          )
+        );
+      }
+    })
+
+    .then(function () {
+      return Promise.resolve();
+    })
+    .then(function () {
+      t.pass('passed');
+    })
+    .catch(function (error) {
+      t.fail('failed with ' + error.toString());
+    })
+    .then(function () {
+      t.end();
+    });
 });

--- a/test/www/jxcore/bv_tests/testThaliReplicationPeerActionCoordinated.js
+++ b/test/www/jxcore/bv_tests/testThaliReplicationPeerActionCoordinated.js
@@ -19,6 +19,7 @@ var ThaliReplicationPeerAction = require('thali/NextGeneration/replication/thali
 var devicePublicPrivateKey = crypto.createECDH(thaliConfig.BEACON_CURVE);
 var devicePublicKey        = devicePublicPrivateKey.generateKeys();
 var TestPouchDB            = testUtils.getLevelDownPouchDb();
+var localPouchDB;
 
 // Use peer's public key to determine local db name. This variable is used in scenario when
 // we want to replicate with remote db which name is different than our local db.
@@ -26,7 +27,8 @@ var TestPouchDB            = testUtils.getLevelDownPouchDb();
 // Use hex encoding to generate string without any special characters.
 var LOCAL_DB_NAME_BASED_ON_PUBLIC_KEY = devicePublicKey.toString('hex').slice(0, 10);
 var LOCAL_DB_NAME          = 'repActionTest';
-var EXPIRATION_TIMEOUT = 60 * 60 * 1000;
+var EXPIRATION_TIMEOUT     = 60 * 60 * 1000;
+var ERROR_NO_DB_FILE       = 'no_db_file';
 
 if (!tape.coordinated) {
   return;
@@ -38,6 +40,10 @@ var test = tape({
     t.end();
   },
   teardown: function (t) {
+    // Make sure we won't get any document conflicts during tests.
+    if (localPouchDB) {
+      localPouchDB.destroy();
+    }
     t.end();
   }
 });
@@ -58,9 +64,9 @@ test('Coordinated replication action test - each device has the same local db na
   var thaliNotificationClient = new ThaliNotificationClient(
     peerPool, devicePublicPrivateKey
   );
-  var localPouchDB = new TestPouchDB(LOCAL_DB_NAME);
-
   var peerActions = [];
+
+  localPouchDB = new TestPouchDB(LOCAL_DB_NAME);
 
   localPouchDB.put({
     _id: JSON.stringify(devicePublicKey.toJSON())
@@ -204,9 +210,9 @@ test('Coordinated replication action test - each device has different local db n
   var thaliNotificationClient = new ThaliNotificationClient(
     peerPool, devicePublicPrivateKey
   );
-  var localPouchDB = new TestPouchDB(LOCAL_DB_NAME_BASED_ON_PUBLIC_KEY);
-
   var peerActions = [];
+
+  localPouchDB = new TestPouchDB(LOCAL_DB_NAME_BASED_ON_PUBLIC_KEY);
 
   localPouchDB.put({
     _id: JSON.stringify(devicePublicKey.toJSON())
@@ -278,6 +284,123 @@ test('Coordinated replication action test - each device has different local db n
             thaliReplicationPeerAction.start(httpAgentPool, remoteDbName)
               .catch(function (error) {
                 exit(error);
+              });
+          });
+        }
+      )
+    })
+
+    .then(function () {
+      return t.sync();
+    })
+
+    .then(function () {
+      // We are simulating thaliPullReplicationFromNotification.stop() and
+      // thaliPeerPoolDefault.stop()
+      thaliNotificationClient.stop();
+      var promises = peerActions.map(function (peerAction) {
+        peerAction.kill();
+        return peerAction.waitUntilKilled();
+      });
+      return Promise.all(promises);
+    })
+    .then(function () {
+      // https://github.com/thaliproject/Thali_CordovaPlugin/issues/1138
+      // workaround for ECONNREFUSED and ECONNRESET from 'request.js' in
+      // 'pouchdb'.
+      return t.sync();
+    })
+    .then(function () {
+      return thaliNotificationServer.stop();
+    })
+    .then(function () {
+      return ThaliMobile.stop();
+    })
+    .then(function (combinedResult) {
+      if (
+        combinedResult.wifiResult   !== null ||
+        combinedResult.nativeResult !== null
+      ) {
+        return Promise.reject(
+          new Error(
+            'Had a failure in ThaliMobile.start - ',
+            JSON.stringify(combinedResult)
+          )
+        );
+      }
+    })
+
+    .then(function () {
+      return Promise.resolve();
+    })
+    .then(function () {
+      t.pass('passed');
+    })
+    .catch(function (error) {
+      t.fail('failed with ' + error.toString());
+    })
+    .then(function () {
+      t.end();
+    });
+});
+
+test('Coordinated replication action test - should throw error when wrong dbRemoteName is provided', function (t) {
+  var wrongRemoteDbName = 'testDb';
+  var router = express.Router();
+  router.use(
+    '/db',
+    expressPouchDB(TestPouchDB, {
+      mode: 'minimumForPouchDB'
+    })
+  );
+  var thaliNotificationServer = new ThaliNotificationServer(
+    router, devicePublicPrivateKey, EXPIRATION_TIMEOUT
+  );
+  var peerPool = new ThaliPeerPoolDefault();
+  peerPool.start();
+  var thaliNotificationClient = new ThaliNotificationClient(
+    peerPool, devicePublicPrivateKey
+  );
+  var peerActions = [];
+
+  localPouchDB = new TestPouchDB(LOCAL_DB_NAME);
+
+  localPouchDB.put({
+    _id: JSON.stringify(devicePublicKey.toJSON())
+  })
+    .then(function () {
+      return testUtils.runTestOnAllParticipants(
+        t, router,
+        thaliNotificationClient,
+        thaliNotificationServer,
+        ThaliMobile,
+        devicePublicKey,
+        function (notificationForUs) {
+          var thaliReplicationPeerAction = new ThaliReplicationPeerAction(
+            notificationForUs, TestPouchDB, LOCAL_DB_NAME, devicePublicKey
+          );
+          peerActions.push(thaliReplicationPeerAction);
+
+          return new Promise(function (resolve, reject) {
+
+            var httpAgentPool = new ForeverAgent.SSL({
+              rejectUnauthorized: false,
+              maxSockets: 8,
+              ciphers: thaliConfig.SUPPORTED_PSK_CIPHERS,
+              pskIdentity: thaliReplicationPeerAction.getPskIdentity(),
+              pskKey: thaliReplicationPeerAction.getPskKey()
+            });
+
+            // This should be rejected since we provided non existing remote db
+            thaliReplicationPeerAction.start(httpAgentPool, wrongRemoteDbName)
+              .then(function() {
+                var error = 'we should not be able to replicate with db that doesn\'t exist';
+                t.fail(error);
+                reject(new Error(error));
+              })
+              .catch(function (error) {
+                t.equals(error.reason, ERROR_NO_DB_FILE, 'error should be \'no_db_file\'');
+                resolve(true);
               });
           });
         }

--- a/thali/NextGeneration/replication/thaliPullReplicationFromNotification.js
+++ b/thali/NextGeneration/replication/thaliPullReplicationFromNotification.js
@@ -45,7 +45,7 @@ var ThaliReplicationPeerAction = require('./thaliReplicationPeerAction');
  * @param {string} localDbName The name of the local DB. The name of the remote DB could be either
  * http://[host from discovery]:[port from discovery]/[BASE_DB_PATH]/[name] where name is
  * taken from pouchDB.info's db_name field or where name is provided during runtime to
- * ThaliReplicationPeerAction when it is being started.
+ * {@link module:ThaliReplicationPeerAction.start} when it is being started.
  * @param {module:thaliPeerPoolInterface~ThaliPeerPoolInterface} thaliPeerPoolInterface
  * @param {Crypto.ECDH} ecdhForLocalDevice A Crypto.ECDH object initialized
  * with the local device's public and private keys.

--- a/thali/NextGeneration/replication/thaliReplicationPeerAction.js
+++ b/thali/NextGeneration/replication/thaliReplicationPeerAction.js
@@ -24,17 +24,17 @@ var Utils = require('../utils/common.js');
  * need for the base class's constructor.
  * @param {PouchDB} PouchDB The PouchDB class constructor we are supposed to
  * use.
- * @param {string} dbName The name of the DB we will use both for local use as
- * well as remote use. Note that we will get the name for the remote database by
- * taking dbName and appending it to http://[hostAddress]:[portNumber]/[BASE_DB_PATH]/
- * [name] where hostAddress and portNumber are from the peerAdvertisesDataForUs
- * argument.
+ * @param {string} localDbName The name of the DB which is dedicated for local usage.
+ * Remote DB url will be created either using localDbName parameter or remoteDbName
+ * parameter, which is provided to ThaliReplicationPeerAction.start method during runtime,
+ * and appending it to http://[hostAddress]:[portNumber]/[BASE_DB_PATH]/[name] where hostAddress
+ * and portNumber are from the peerAdvertisesDataForUs argument.
  * @param {Buffer} ourPublicKey The buffer containing our ECDH public key
  * @constructor
  */
 function ThaliReplicationPeerAction(peerAdvertisesDataForUs,
                                     PouchDB,
-                                    dbName,
+                                    localDbName,
                                     ourPublicKey) {
   assert(ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS * 1000 -
     ThaliReplicationPeerAction.PUSH_LAST_SYNC_UPDATE_MILLISECONDS >
@@ -42,7 +42,7 @@ function ThaliReplicationPeerAction(peerAdvertisesDataForUs,
     'that at least one sync update will have gone out before we time out.');
   assert(peerAdvertisesDataForUs, 'there must be peerAdvertisesDataForUs');
   assert(PouchDB, 'there must be PouchDB');
-  assert(dbName, 'there must be dbName');
+  assert(localDbName, 'there must be localDbName');
   assert(ourPublicKey, 'there must be an ourPublicKey');
 
   ThaliReplicationPeerAction.super_.call(this, peerAdvertisesDataForUs.keyId,
@@ -53,7 +53,7 @@ function ThaliReplicationPeerAction(peerAdvertisesDataForUs,
 
   this._peerAdvertisesDataForUs = peerAdvertisesDataForUs;
   this._PouchDB = PouchDB;
-  this._dbName = dbName;
+  this._localDbName = localDbName;
   this._ourPublicKey = ourPublicKey;
   this._localSeqManager = null;
   this._cancelReplication = null;
@@ -107,7 +107,7 @@ ThaliReplicationPeerAction.prototype.getPeerAdvertisesDataForUs = function () {
  */
 ThaliReplicationPeerAction.prototype.clone = function () {
   return new ThaliReplicationPeerAction(this._peerAdvertisesDataForUs,
-    this._PouchDB, this._dbName, this._ourPublicKey);
+    this._PouchDB, this._localDbName, this._ourPublicKey);
 };
 
 /**
@@ -190,9 +190,15 @@ ThaliReplicationPeerAction.prototype._replicationTimer = function () {
  * @param {http.Agent} httpAgentPool This is the HTTP connection pool to use
  * when creating HTTP requests related to this action. Note that this is where
  * the PSK related settings are specified.
+ * @param {string} remoteDbName The name of remote DB that we will try to replicate
+ * with. This parameter is used to create a proper url to remote database. If it is
+ * not provided, for example by ThaliPeerPoolInterface custom implementation,
+ * we assume that the remote DB name is the same as our local one.
+ * The reason why it is not provided in constructor is that at the time of creating
+ * instance of this object, we simply don't know such information.
  * @returns {Promise<?Error>}
  */
-ThaliReplicationPeerAction.prototype.start = function (httpAgentPool) {
+ThaliReplicationPeerAction.prototype.start = function (httpAgentPool, remoteDbName) {
   var self = this;
   this._completed = false;
 
@@ -201,7 +207,7 @@ ThaliReplicationPeerAction.prototype.start = function (httpAgentPool) {
     .then(function () {
       var remoteUrl = 'https://' + self._peerAdvertisesDataForUs.hostAddress +
         ':' + self._peerAdvertisesDataForUs.portNumber +
-        path.join(thaliConfig.BASE_DB_PATH, self._dbName);
+        path.join(thaliConfig.BASE_DB_PATH, !!remoteDbName ? remoteDbName : self._localDbName);
       var ajaxOptions = {
         ajax : {
           agent: httpAgentPool
@@ -217,7 +223,7 @@ ThaliReplicationPeerAction.prototype.start = function (httpAgentPool) {
         self._resolve = resolve;
         self._reject = reject;
         self._replicationTimer();
-        self._cancelReplication = remoteDB.replicate.to(self._dbName, {
+        self._cancelReplication = remoteDB.replicate.to(self._localDbName, {
           live: true
         })
         .on('paused', function (err) {

--- a/thali/NextGeneration/replication/thaliReplicationPeerAction.js
+++ b/thali/NextGeneration/replication/thaliReplicationPeerAction.js
@@ -190,12 +190,13 @@ ThaliReplicationPeerAction.prototype._replicationTimer = function () {
  * @param {http.Agent} httpAgentPool This is the HTTP connection pool to use
  * when creating HTTP requests related to this action. Note that this is where
  * the PSK related settings are specified.
- * @param {string} remoteDbName The name of remote DB that we will try to replicate
- * with. This parameter is used to create a proper url to remote database. If it is
- * not provided, for example by {@link module:thaliPeerPoolInterface~ThaliPeerPoolInterface}
- * custom implementation, we assume that the remote DB name is the same as our local one.
- * The reason why it is not provided in constructor is that at the time of creating
- * instance of this object, we simply don't know such information.
+ * @param {string} [remoteDbName] Optional parameter that specifies name of remote
+ * DB that we will try to replicate with. This parameter is used to create a proper
+ * url to remote database. If it is not provided, for example by
+ * {@link module:thaliPeerPoolInterface~ThaliPeerPoolInterface} custom implementation,
+ * we assume that the remote DB name is the same as our local one. The reason why it is
+ * not provided in constructor is that at the time of creating instance of this object,
+ * we simply don't know such information.
  * @returns {Promise<?Error>}
  */
 ThaliReplicationPeerAction.prototype.start = function (httpAgentPool, remoteDbName) {

--- a/thali/NextGeneration/replication/thaliReplicationPeerAction.js
+++ b/thali/NextGeneration/replication/thaliReplicationPeerAction.js
@@ -26,7 +26,7 @@ var Utils = require('../utils/common.js');
  * use.
  * @param {string} localDbName The name of the DB which is dedicated for local usage.
  * Remote DB url will be created either using localDbName parameter or remoteDbName
- * parameter, which is provided to ThaliReplicationPeerAction.start method during runtime,
+ * parameter, which is provided to {@link module:ThaliReplicationPeerAction.start} during runtime,
  * and appending it to http://[hostAddress]:[portNumber]/[BASE_DB_PATH]/[name] where hostAddress
  * and portNumber are from the peerAdvertisesDataForUs argument.
  * @param {Buffer} ourPublicKey The buffer containing our ECDH public key
@@ -192,8 +192,8 @@ ThaliReplicationPeerAction.prototype._replicationTimer = function () {
  * the PSK related settings are specified.
  * @param {string} remoteDbName The name of remote DB that we will try to replicate
  * with. This parameter is used to create a proper url to remote database. If it is
- * not provided, for example by ThaliPeerPoolInterface custom implementation,
- * we assume that the remote DB name is the same as our local one.
+ * not provided, for example by {@link module:thaliPeerPoolInterface~ThaliPeerPoolInterface}
+ * custom implementation, we assume that the remote DB name is the same as our local one.
  * The reason why it is not provided in constructor is that at the time of creating
  * instance of this object, we simply don't know such information.
  * @returns {Promise<?Error>}

--- a/thali/NextGeneration/thaliManager.js
+++ b/thali/NextGeneration/thaliManager.js
@@ -27,8 +27,9 @@ var assert = require('assert');
  * dbs. Typically this should have PouchDB.defaults set with db to
  * require('leveldown-mobile') and prefix to the path where the application
  * wishes to store the DB.
- * @param {string} localDbName Name of the db that we , both locally and remotely that we are
- * interacting with.
+ * @param {string} localDbName Name of the db that we are interacting with locally.
+ * The remote db name will be resolved either by using this parameter or by using
+ * {string} remoteDbName parameter passed to {@link module:ThaliReplicationPeerAction.start}.
  * @param {Crypto.ECDH} ecdhForLocalDevice A Crypto.ECDH object initialized with
  * the local device's public and private keys.
  * @param {module:thaliPeerPoolInterface~ThaliPeerPoolInterface} [thaliPeerPoolInterface]

--- a/thali/NextGeneration/thaliManager.js
+++ b/thali/NextGeneration/thaliManager.js
@@ -27,7 +27,7 @@ var assert = require('assert');
  * dbs. Typically this should have PouchDB.defaults set with db to
  * require('leveldown-mobile') and prefix to the path where the application
  * wishes to store the DB.
- * @param {string} dbName Name of the db, both locally and remotely that we are
+ * @param {string} localDbName Name of the db that we , both locally and remotely that we are
  * interacting with.
  * @param {Crypto.ECDH} ecdhForLocalDevice A Crypto.ECDH object initialized with
  * the local device's public and private keys.
@@ -42,7 +42,7 @@ var assert = require('assert');
 function ThaliManager(
   expressPouchDB,
   PouchDB,
-  dbName,
+  localDbName,
   ecdhForLocalDevice,
   thaliPeerPoolInterface,
   networkType
@@ -53,7 +53,7 @@ function ThaliManager(
   this._router.all('*', this._connectionFilter.bind(this));
 
   this._router.all('*', salti(
-    dbName,
+    localDbName,
     ThaliManager._acl,
     this._resolveThaliId.bind(this),
     { dbPrefix: thaliConfig.BASE_DB_PATH }
@@ -66,7 +66,7 @@ function ThaliManager(
         this._router,
         ecdhForLocalDevice,
         thaliConfig.BEACON_MILLISECONDS_TO_EXPIRE,
-        new PouchDB(dbName));
+        new PouchDB(localDbName));
   this._getPskIdToSecret =
     self._thaliSendNotificationBasedOnReplication.getPskIdToSecret();
   this._getPskIdToPublicKey =
@@ -77,7 +77,7 @@ function ThaliManager(
   this._thaliPullReplicationFromNotification =
     new ThaliPullReplicationFromNotification(
         PouchDB,
-        dbName,
+        localDbName,
         thaliPeerPoolInterface,
         ecdhForLocalDevice);
   this._thaliPeerPoolInterface = thaliPeerPoolInterface;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1876)
<!-- Reviewable:end -->
