### PR TITLE
Add possibility to provide custom No activity timeout value to ReplicationAction

### DIFF
--- a/test/www/jxcore/bv_tests/testThaliReplicationPeerAction.js
+++ b/test/www/jxcore/bv_tests/testThaliReplicationPeerAction.js
@@ -470,10 +470,10 @@ test('Replication timer should use custom timeout value when its provided when c
                 devicePublicKey);
 
         setTimeout(function () {
-          if (!replicationActionEnd) {
+          if (replicationActionEnd) {
             t.fail('Replication timer should use custom timeout value');
           }
-        }, 4);
+        }, 4 * 1000);
 
         thaliReplicationPeerAction.start(httpAgentPool, randomDBName, customTimeout)
             .then(function () {
@@ -522,10 +522,10 @@ test('Replication timer should use default timeout value when its not provided w
                 devicePublicKey);
 
         setTimeout(function () {
-          if (!replicationActionEnd) {
+          if (replicationActionEnd) {
             t.fail('Replication timer should use custom timeout value');
           }
-        }, ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS - 2);
+        }, 2 * 1000);
 
         thaliReplicationPeerAction.start(httpAgentPool)
             .then(function () {

--- a/test/www/jxcore/bv_tests/testThaliReplicationPeerAction.js
+++ b/test/www/jxcore/bv_tests/testThaliReplicationPeerAction.js
@@ -442,6 +442,111 @@ test('Do something and make sure we time out',
   }
 );
 
+test('Replication timer should use custom timeout value when its provided when calling start',
+    function (t) {
+      function onServerSetUp (serverPort, randomDBName) {
+        var thaliReplicationPeerAction = null;
+        var notificationForUs = {
+          keyId: new Buffer('abcdefg'),
+          portNumber: serverPort,
+          hostAddress: '127.0.0.1',
+          pskIdentifyField: pskId,
+          psk: pskKey,
+          suggestedTCPTimeout: 10000,
+          connectionType: thaliMobileNativeWrapper.connectionTypes.TCP_NATIVE
+        };
+        // Using a different directory really shouldn't make any difference
+        // to this particular test but I'm being paranoid
+        var DifferentDirectoryPouch = testUtils.getLevelDownPouchDb();
+        // Change default value to 2, so we will be sure that timer is using our value
+        var originalTimeout = ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS;
+        ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS = 2;
+        var customTimeout = 6;
+        var replicationActionEnd = false;
+
+        thaliReplicationPeerAction =
+            new ThaliReplicationPeerAction(notificationForUs,
+                DifferentDirectoryPouch, randomDBName,
+                devicePublicKey);
+
+        setTimeout(function () {
+          if (!replicationActionEnd) {
+            t.fail('Replication timer should use custom timeout value');
+          }
+        }, 4);
+
+        thaliReplicationPeerAction.start(httpAgentPool, randomDBName, customTimeout)
+            .then(function () {
+              t.fail('We should have failed with time out.');
+            })
+            .catch(function (err) {
+              replicationActionEnd = true;
+              t.equal(thaliReplicationPeerAction.getActionState(),
+                  PeerAction.actionState.KILLED,
+                  'action should be killed');
+              t.equal(err.message, 'No activity time out', 'Error should be timed ' +
+                  'out');
+
+              ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS = originalTimeout;
+              t.end();
+            });
+      }
+      testCloseAllServer = testUtils.setUpServer(onServerSetUp);
+    }
+);
+
+test('Replication timer should use default timeout value when its not provided when calling start',
+    function (t) {
+      function onServerSetUp (serverPort, randomDBName) {
+        var thaliReplicationPeerAction = null;
+        var notificationForUs = {
+          keyId: new Buffer('abcdefg'),
+          portNumber: serverPort,
+          hostAddress: '127.0.0.1',
+          pskIdentifyField: pskId,
+          psk: pskKey,
+          suggestedTCPTimeout: 10000,
+          connectionType: thaliMobileNativeWrapper.connectionTypes.TCP_NATIVE
+        };
+        // Using a different directory really shouldn't make any difference
+        // to this particular test but I'm being paranoid
+        var DifferentDirectoryPouch = testUtils.getLevelDownPouchDb();
+        // Change default value to 2, so we will be sure that timer is using our value
+        var originalTimeout = ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS;
+        ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS = 4;
+        var replicationActionEnd = false;
+
+        thaliReplicationPeerAction =
+            new ThaliReplicationPeerAction(notificationForUs,
+                DifferentDirectoryPouch, randomDBName,
+                devicePublicKey);
+
+        setTimeout(function () {
+          if (!replicationActionEnd) {
+            t.fail('Replication timer should use custom timeout value');
+          }
+        }, ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS - 2);
+
+        thaliReplicationPeerAction.start(httpAgentPool)
+            .then(function () {
+              t.fail('We should have failed with time out.');
+            })
+            .catch(function (err) {
+              replicationActionEnd = true;
+              t.equal(thaliReplicationPeerAction.getActionState(),
+                  PeerAction.actionState.KILLED,
+                  'action should be killed');
+              t.equal(err.message, 'No activity time out', 'Error should be timed ' +
+                  'out');
+
+              ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS = originalTimeout;
+              t.end();
+            });
+      }
+      testCloseAllServer = testUtils.setUpServer(onServerSetUp);
+    }
+);
+
 test('Start replicating and then catch error when server goes', function (t) {
   var requestCount = 0;
   function killServer(app) {

--- a/thali/NextGeneration/replication/thaliReplicationPeerAction.js
+++ b/thali/NextGeneration/replication/thaliReplicationPeerAction.js
@@ -118,15 +118,18 @@ ThaliReplicationPeerAction.prototype.clone = function () {
  * actually doing useful work. This timer however is connected directly to the
  * changes feed and so can see if 'useful' work is happening and time out if it
  * is not.
+ * @param {Number} maxIdlePeriodSeconds Number of seconds of no activity that we
+ * will wait before killing the action. Be default we wait 3s, but because of #1961,
+ * we provide optional parameter that can be used by policy manager.
  * @private
  */
-ThaliReplicationPeerAction.prototype._replicationTimer = function () {
+ThaliReplicationPeerAction.prototype._replicationTimer = function (maxIdlePeriodSeconds) {
   var self = this;
   if (self._refreshTimerManager) {
     self._refreshTimerManager.stop();
   }
   self._refreshTimerManager = new RefreshTimerManager(
-    ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS * 1000,
+    !!maxIdlePeriodSeconds ? maxIdlePeriodSeconds * 1000 : ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS * 1000,
     function() {
       self._complete([new Error('No activity time out')]);
     });
@@ -193,13 +196,16 @@ ThaliReplicationPeerAction.prototype._replicationTimer = function () {
  * @param {string} [remoteDbName] Optional parameter that specifies name of remote
  * DB that we will try to replicate with. This parameter is used to create a proper
  * url to remote database. If it is not provided, for example by
+ * @param {Number} maxIdlePeriodSeconds Number of seconds of no activity that we
+ * will wait before killing the action. Be default we wait 3s, but because of #1961,
+ * we provide optional parameter that can be used by policy manager.
  * {@link module:thaliPeerPoolInterface~ThaliPeerPoolInterface} custom implementation,
  * we assume that the remote DB name is the same as our local one. The reason why it is
  * not provided in constructor is that at the time of creating instance of this object,
  * we simply don't know such information.
  * @returns {Promise<?Error>}
  */
-ThaliReplicationPeerAction.prototype.start = function (httpAgentPool, remoteDbName) {
+ThaliReplicationPeerAction.prototype.start = function (httpAgentPool, remoteDbName, maxIdlePeriodSeconds) {
   var self = this;
   this._completed = false;
 
@@ -223,7 +229,7 @@ ThaliReplicationPeerAction.prototype.start = function (httpAgentPool, remoteDbNa
       self._replicationPromise = new Promise(function (resolve, reject) {
         self._resolve = resolve;
         self._reject = reject;
-        self._replicationTimer();
+        self._replicationTimer(maxIdlePeriodSeconds);
         self._cancelReplication = remoteDB.replicate.to(self._localDbName, {
           live: true
         })

--- a/thali/NextGeneration/replication/thaliReplicationPeerAction.js
+++ b/thali/NextGeneration/replication/thaliReplicationPeerAction.js
@@ -129,7 +129,7 @@ ThaliReplicationPeerAction.prototype._replicationTimer = function (maxIdlePeriod
     self._refreshTimerManager.stop();
   }
   self._refreshTimerManager = new RefreshTimerManager(
-    !!maxIdlePeriodSeconds ? maxIdlePeriodSeconds * 1000 : ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS * 1000,
+      (!!maxIdlePeriodSeconds ? maxIdlePeriodSeconds : ThaliReplicationPeerAction.MAX_IDLE_PERIOD_SECONDS) * 1000,
     function() {
       self._complete([new Error('No activity time out')]);
     });


### PR DESCRIPTION
This will allow to provide custom No activity timeout value when starting Replication Action directly from policy manager, which should solve some issues with slow radios such as Bluetooth especially on Android devices, see #1961.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/thali_cordovaplugin/1962)
<!-- Reviewable:end -->
